### PR TITLE
Add sentence construction and speech recognition exercises

### DIFF
--- a/luxembourgish-app/docs/sentence-speech-exercises-spec.md
+++ b/luxembourgish-app/docs/sentence-speech-exercises-spec.md
@@ -1,0 +1,66 @@
+# Sentence Construction & Speech Recognition Exercises - Specification
+
+## 🎯 Contexte
+L'application propose déjà plusieurs types d'exercices (audio, images, dialogues, prononciation). Lors de la conception initiale, deux modules supplémentaires étaient prévus pour enrichir l'apprentissage :
+
+1. **Construction de phrase** — guider l'apprenant dans la structuration de phrases courantes en luxembourgeois.
+2. **Speech recognition** — évaluer une phrase prononcée en comparant la transcription vocale à la cible attendue.
+
+Ces fonctionnalités doivent s'intégrer harmonieusement dans l'architecture existante (`LearningUnit`, `Exercise`, composants d'exercices) et respecter l'expérience utilisateur "Duolingo-like".
+
+## ✅ Objectifs
+- Étendre le modèle d'exercice pour supporter les deux nouveaux types.
+- Offrir une UI accessible et tactile pour organiser des mots (sentence builder).
+- Mettre en place un flux de reconnaissance vocale robuste avec fallback si l'API n'est pas disponible.
+- Conserver les feedbacks audio/visuels et les métriques (temps, réussite) déjà utilisés.
+- Ajouter des exercices pertinents dans chaque unité de cours afin d'exposer ces nouvelles mécaniques.
+
+## 🧠 User stories
+- *En tant qu'apprenant*, je peux réordonner des mots proposés pour former une phrase correcte et recevoir un feedback immédiat.
+- *En tant qu'apprenant*, je peux prononcer une phrase complète, voir la transcription de mon essai et savoir si ma prononciation/structure correspond à la cible.
+- *En tant que concepteur*, je peux créer facilement de nouveaux exercices de ces types via les fichiers de données sans modifier les composants.
+
+## 🧱 Mise à jour du modèle de données
+- Ajouter deux valeurs à `ExerciseType` : `sentence_construction` et `speech_recognition`.
+- Étendre l'interface `Exercise` avec des propriétés optionnelles :
+  - `wordBank?: string[]` — banque de mots à utiliser pour la construction.
+  - `expectedSentence?: string` — phrase canonique utilisée pour les comparaisons (sinon `correctAnswer`).
+  - `hint?: string` — courte aide contextuelle affichée sous la consigne.
+- Mettre à jour les fichiers `Unit*Data.ts` pour fournir ces champs pour les nouveaux exercices.
+
+## 🖥️ UX / UI
+### Construction de phrase
+- Afficher la consigne et un éventuel contexte.
+- Montrer un espace "Phrase" où les mots sélectionnés apparaissent dans l'ordre.
+- Liste de boutons/étiquettes représentant le `wordBank`.
+- Les mots déjà utilisés deviennent désactivés (ou grisés) pour éviter les doublons.
+- Bouton « Effacer » pour réinitialiser la tentative.
+- Lorsque tous les mots sont utilisés ou que l'utilisateur valide, comparer au modèle et afficher un feedback (succès/erreur + phrase correcte).
+
+### Speech recognition
+- Afficher la phrase cible (ou un indice) et un bouton "Écouter" pour entendre le modèle.
+- Bouton principal pour démarrer/arrêter l'enregistrement.
+- Afficher l'état (enregistrement en cours, absence de support navigateur, fallback simulé).
+- Montrer la transcription détectée en temps réel ou à la fin.
+- Calculer une similarité pour déterminer la réussite, puis feedback (succès/encouragement) + possibilité de réessayer.
+
+## ⚙️ Implémentation technique
+1. **Types** — mettre à jour `LearningTypes.ts` et fournir une déclaration `SpeechRecognition` typée (fichier `src/types/speech-recognition.d.ts`).
+2. **Services** — créer `SpeechRecognitionService` qui encapsule la logique start/stop, la détection de support et la normalisation de transcript.
+3. **Composants** — ajouter `SentenceConstructionExercise` et `SpeechRecognitionExercise` dans `src/components/exercises`.
+   - Les composants suivent la même API (`exercise`, `onComplete`).
+   - Utilisation de `AudioService` pour la lecture modèle.
+4. **Intégration** — mettre à jour `LearningUnit.tsx` (switch sur type et libellés de bandeau).
+5. **Données** — enrichir chaque unité avec au moins un exercice de chaque nouveau type pour assurer la couverture.
+6. **Feedback / audio** — réutiliser `AudioService` pour les interactions utilisateur (clic, lecture, etc.).
+
+## 🧪 Plan de test
+- Navigation complète dans une unité contenant les nouveaux exercices.
+- Interaction tactile/clavier sur les mots (construction).
+- Simulation du flux speech recognition avec navigateur sans support (fallback) et s'assurer que la complétion appelle `onComplete`.
+- `npm run build` pour valider la compilation TypeScript.
+
+## 🚀 Livrables
+- Nouveaux composants d'exercice et service de reconnaissance vocale.
+- Données mises à jour pour exposer les exercices.
+- Documentation de ces spécifications (`docs/sentence-speech-exercises-spec.md`).

--- a/luxembourgish-app/src/components/LearningUnit.tsx
+++ b/luxembourgish-app/src/components/LearningUnit.tsx
@@ -26,6 +26,8 @@ import ImageAssociationExercise from './exercises/ImageAssociationExercise'
 import TranslationExercise from './exercises/TranslationExercise'
 import DialogueCompletionExercise from './exercises/DialogueCompletionExercise'
 import PronunciationExercise from './exercises/PronunciationExercise'
+import SentenceConstructionExercise from './exercises/SentenceConstructionExercise'
+import SpeechRecognitionExercise from './exercises/SpeechRecognitionExercise'
 import { keyframes } from '@mui/system'
 import { AudioService } from '../services/AudioService'
 
@@ -148,6 +150,10 @@ const LearningUnit = ({ unit, onUnitComplete, onExit }: LearningUnitProps) => {
         return <DialogueCompletionExercise key={currentExercise.id} {...exerciseProps} />
       case 'pronunciation':
         return <PronunciationExercise key={currentExercise.id} {...exerciseProps} />
+      case 'sentence_construction':
+        return <SentenceConstructionExercise key={currentExercise.id} {...exerciseProps} />
+      case 'speech_recognition':
+        return <SpeechRecognitionExercise key={currentExercise.id} {...exerciseProps} />
       default:
         return <Typography variant="body1">Type d'exercice non supporté</Typography>
     }
@@ -276,7 +282,9 @@ const getExerciseTypeName = (type?: Exercise['type']): string => {
     image_association: 'Association situation',
     translation: 'Traduction',
     dialogue_completion: 'Dialogue',
-    pronunciation: 'Prononciation'
+    pronunciation: 'Prononciation',
+    sentence_construction: 'Construction de phrase',
+    speech_recognition: 'Reconnaissance vocale'
   }
 
   if (!type) {

--- a/luxembourgish-app/src/components/exercises/SentenceConstructionExercise.tsx
+++ b/luxembourgish-app/src/components/exercises/SentenceConstructionExercise.tsx
@@ -1,0 +1,232 @@
+import { useMemo, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Stack,
+  Typography
+} from '@mui/material'
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
+import CancelRoundedIcon from '@mui/icons-material/CancelRounded'
+import ReplayRoundedIcon from '@mui/icons-material/ReplayRounded'
+import VolumeUpRoundedIcon from '@mui/icons-material/VolumeUpRounded'
+import TipsAndUpdatesRoundedIcon from '@mui/icons-material/TipsAndUpdatesRounded'
+import { Exercise } from '../../types/LearningTypes'
+import { AudioService } from '../../services/AudioService'
+import { SpeechRecognitionService } from '../../services/SpeechRecognitionService'
+
+interface SentenceConstructionExerciseProps {
+  exercise: Exercise
+  onComplete: (isCorrect: boolean, timeSpent: number, attempts?: number) => void
+}
+
+interface WordToken {
+  id: string
+  label: string
+}
+
+const SentenceConstructionExercise = ({ exercise, onComplete }: SentenceConstructionExerciseProps) => {
+  const [selectedTokenIds, setSelectedTokenIds] = useState<string[]>([])
+  const [hasAnswered, setHasAnswered] = useState(false)
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null)
+  const [attempts, setAttempts] = useState(0)
+  const [startTime] = useState(() => Date.now())
+
+  const wordTokens = useMemo<WordToken[]>(() => {
+    const bank = exercise.wordBank?.length
+      ? exercise.wordBank
+      : exercise.options?.length
+      ? exercise.options
+      : exercise.correctAnswer.split(' ')
+
+    return bank.map((word, index) => ({ id: `${word}-${index}`, label: word }))
+  }, [exercise.correctAnswer, exercise.options, exercise.wordBank])
+
+  const expectedSentence = useMemo(() => {
+    return exercise.expectedSentence ?? exercise.correctAnswer
+  }, [exercise.correctAnswer, exercise.expectedSentence])
+
+  const selectedTokens = selectedTokenIds
+    .map(tokenId => wordTokens.find(token => token.id === tokenId))
+    .filter((token): token is WordToken => Boolean(token))
+
+  const availableTokens = wordTokens.filter(token => !selectedTokenIds.includes(token.id))
+
+  const handleWordSelect = (tokenId: string) => {
+    if (hasAnswered) return
+    if (selectedTokenIds.includes(tokenId)) return
+
+    setSelectedTokenIds(prev => [...prev, tokenId])
+  }
+
+  const handleRemoveToken = (tokenId: string) => {
+    if (hasAnswered) return
+
+    setSelectedTokenIds(prev => prev.filter(id => id !== tokenId))
+  }
+
+  const resetSelection = () => {
+    if (hasAnswered) return
+
+    setSelectedTokenIds([])
+  }
+
+  const speakSentence = async () => {
+    AudioService.playClickSound()
+
+    try {
+      await AudioService.speakLuxembourgish(expectedSentence, 0.75)
+    } catch (error) {
+      console.warn('Pronunciation failed:', error)
+    }
+  }
+
+  const handleValidate = () => {
+    if (hasAnswered || selectedTokens.length === 0) return
+
+    const userSentence = selectedTokens.map(token => token.label).join(' ')
+    const { isCorrect: resultIsCorrect } = SpeechRecognitionService.scoreTranscript(expectedSentence, userSentence)
+
+    const attemptCount = attempts + 1
+    setAttempts(attemptCount)
+    setHasAnswered(true)
+    setIsCorrect(resultIsCorrect)
+
+    const timeSpent = Date.now() - startTime
+
+    setTimeout(() => {
+      onComplete(resultIsCorrect, timeSpent, attemptCount)
+    }, 1500)
+  }
+
+  const showHint = !hasAnswered && (exercise.hint || exercise.context)
+
+  return (
+    <Stack spacing={3}>
+      <Stack spacing={1.5}>
+        <Typography variant="h5">Construction de phrase</Typography>
+        <Typography variant="body2" color="text.secondary">
+          {exercise.question}
+        </Typography>
+        {showHint && (
+          <Alert severity="info" icon={<TipsAndUpdatesRoundedIcon />}>
+            {exercise.hint || exercise.context}
+          </Alert>
+        )}
+      </Stack>
+
+      <Stack spacing={2}>
+        <Box
+          sx={{
+            borderRadius: 3,
+            backgroundColor: 'rgba(25,118,210,0.06)',
+            p: { xs: 2, md: 3 },
+            minHeight: 96,
+            display: 'flex',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: 1.5
+          }}
+        >
+          {selectedTokens.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              Sélectionnez les mots dans l'ordre pour construire la phrase.
+            </Typography>
+          ) : (
+            selectedTokens.map(token => (
+              <Chip
+                key={token.id}
+                label={token.label}
+                color="primary"
+                variant="filled"
+                onClick={() => handleRemoveToken(token.id)}
+                disabled={hasAnswered}
+                sx={{
+                  fontSize: '1rem',
+                  px: 1.5,
+                  py: 0.5,
+                  borderRadius: 2,
+                  cursor: hasAnswered ? 'default' : 'pointer'
+                }}
+              />
+            ))
+          )}
+        </Box>
+
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          {availableTokens.map(token => (
+            <Button
+              key={token.id}
+              variant="outlined"
+              color="primary"
+              onClick={() => handleWordSelect(token.id)}
+              disabled={hasAnswered}
+              sx={{
+                borderRadius: 3,
+                textTransform: 'none',
+                fontWeight: 600
+              }}
+            >
+              {token.label}
+            </Button>
+          ))}
+        </Stack>
+      </Stack>
+
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleValidate}
+          disabled={hasAnswered || selectedTokens.length === 0}
+          endIcon={hasAnswered ? (isCorrect ? <CheckCircleRoundedIcon /> : <CancelRoundedIcon />) : undefined}
+        >
+          Valider la phrase
+        </Button>
+        <Button
+          variant="outlined"
+          color="secondary"
+          onClick={resetSelection}
+          disabled={hasAnswered || selectedTokens.length === 0}
+          startIcon={<ReplayRoundedIcon />}
+        >
+          Effacer
+        </Button>
+        <Button
+          variant="text"
+          color="primary"
+          onClick={speakSentence}
+          startIcon={<VolumeUpRoundedIcon />}
+        >
+          Écouter la phrase
+        </Button>
+      </Stack>
+
+      {hasAnswered && (
+        <Alert severity={isCorrect ? 'success' : 'error'} icon={isCorrect ? <CheckCircleRoundedIcon /> : <CancelRoundedIcon />}>
+          {isCorrect
+            ? 'Bravo ! La phrase est correcte.'
+            : 'Presque ! Voici la phrase correcte :'}
+        </Alert>
+      )}
+
+      {hasAnswered && !isCorrect && (
+        <Box
+          sx={{
+            borderRadius: 3,
+            backgroundColor: 'rgba(239,68,68,0.08)',
+            p: { xs: 2, md: 3 }
+          }}
+        >
+          <Typography variant="subtitle1">Phrase attendue</Typography>
+          <Typography variant="body1" sx={{ fontWeight: 600 }}>
+            {expectedSentence}
+          </Typography>
+        </Box>
+      )}
+    </Stack>
+  )
+}
+
+export default SentenceConstructionExercise

--- a/luxembourgish-app/src/components/exercises/SpeechRecognitionExercise.tsx
+++ b/luxembourgish-app/src/components/exercises/SpeechRecognitionExercise.tsx
@@ -1,0 +1,215 @@
+import { useMemo, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Stack,
+  Typography
+} from '@mui/material'
+import MicRoundedIcon from '@mui/icons-material/MicRounded'
+import StopRoundedIcon from '@mui/icons-material/StopRounded'
+import VolumeUpRoundedIcon from '@mui/icons-material/VolumeUpRounded'
+import GraphicEqRoundedIcon from '@mui/icons-material/GraphicEqRounded'
+import TipsAndUpdatesRoundedIcon from '@mui/icons-material/TipsAndUpdatesRounded'
+import { Exercise } from '../../types/LearningTypes'
+import { AudioService } from '../../services/AudioService'
+import { SpeechRecognitionService } from '../../services/SpeechRecognitionService'
+
+interface SpeechRecognitionExerciseProps {
+  exercise: Exercise
+  onComplete: (isCorrect: boolean, timeSpent: number, attempts?: number) => void
+}
+
+const SpeechRecognitionExercise = ({ exercise, onComplete }: SpeechRecognitionExerciseProps) => {
+  const [isRecording, setIsRecording] = useState(false)
+  const [transcript, setTranscript] = useState('')
+  const [result, setResult] = useState<{ isCorrect: boolean; similarity: number } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [attempts, setAttempts] = useState(0)
+  const [startTime] = useState(() => Date.now())
+
+  const speechSupported = useMemo(() => SpeechRecognitionService.isSupported(), [])
+  const expectedSentence = useMemo(() => exercise.expectedSentence ?? exercise.correctAnswer, [exercise.correctAnswer, exercise.expectedSentence])
+
+  const handlePlayModel = async () => {
+    AudioService.playClickSound()
+
+    try {
+      await AudioService.speakLuxembourgish(expectedSentence, 0.75)
+    } catch (err) {
+      console.warn('Pronunciation failed:', err)
+    }
+  }
+
+  const finalizeAttempt = (finalTranscript: string) => {
+    const scoring = SpeechRecognitionService.scoreTranscript(expectedSentence, finalTranscript)
+    const attemptNumber = attempts + 1
+
+    setTranscript(finalTranscript)
+    setResult(scoring)
+    setAttempts(attemptNumber)
+    setIsRecording(false)
+
+    const timeSpent = Date.now() - startTime
+
+    setTimeout(() => {
+      onComplete(scoring.isCorrect, timeSpent, attemptNumber)
+    }, 1800)
+  }
+
+  const startRecognition = () => {
+    setError(null)
+    setResult(null)
+
+    if (speechSupported) {
+      try {
+        SpeechRecognitionService.startRecognition({
+          language: 'lb-LU',
+          interimResults: false,
+          continuous: false,
+          onStart: () => {
+            setIsRecording(true)
+          },
+          onResult: (capturedTranscript) => {
+            finalizeAttempt(capturedTranscript)
+          },
+          onEnd: () => {
+            setIsRecording(false)
+          },
+          onError: (err) => {
+            console.warn('Speech recognition error:', err)
+            setError("Une erreur est survenue. Mode simulation activé.")
+            runSimulation()
+          }
+        })
+      } catch (err) {
+        console.warn('Speech recognition start failed:', err)
+        setError("Reconnaissance vocale indisponible. Mode simulation activé.")
+        runSimulation()
+      }
+    } else {
+      runSimulation()
+    }
+  }
+
+  const stopRecognition = () => {
+    if (!speechSupported) return
+
+    SpeechRecognitionService.stopRecognition()
+    setIsRecording(false)
+  }
+
+  const runSimulation = () => {
+    setIsRecording(true)
+
+    SpeechRecognitionService.simulateRecognition(expectedSentence, (simulatedTranscript) => {
+      finalizeAttempt(simulatedTranscript)
+    })
+  }
+
+  const handleMicrophoneClick = () => {
+    if (isRecording && speechSupported) {
+      stopRecognition()
+      return
+    }
+
+    if (isRecording) {
+      // Simulation en cours, on ignore les clics
+      return
+    }
+
+    startRecognition()
+  }
+
+  const similarityPercentage = result ? Math.round(result.similarity * 100) : null
+
+  return (
+    <Stack spacing={3}>
+      <Stack spacing={1.5}>
+        <Typography variant="h5">Speech recognition</Typography>
+        <Typography variant="body2" color="text.secondary">
+          {exercise.question}
+        </Typography>
+        {(exercise.hint || exercise.context) && (
+          <Alert severity="info" icon={<TipsAndUpdatesRoundedIcon />}>
+            {exercise.hint || exercise.context}
+          </Alert>
+        )}
+        {!speechSupported && (
+          <Alert severity="warning" icon={<GraphicEqRoundedIcon />}>
+            Votre navigateur ne supporte pas la reconnaissance vocale. Nous allons simuler le résultat pour que vous puissiez continuer.
+          </Alert>
+        )}
+      </Stack>
+
+      <Box
+        sx={{
+          borderRadius: 3,
+          background: 'linear-gradient(135deg, rgba(25,118,210,0.08) 0%, rgba(20,184,166,0.08) 100%)',
+          p: { xs: 2, md: 3 }
+        }}
+      >
+        <Typography variant="subtitle2" color="text.secondary">
+          Phrase cible
+        </Typography>
+        <Typography variant="h5">{expectedSentence}</Typography>
+        <Chip label={exercise.vocabularyItem.luxembourgish} color="primary" sx={{ mt: 1 }} />
+      </Box>
+
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+        <Button
+          variant="contained"
+          color={isRecording && speechSupported ? 'error' : 'primary'}
+          onClick={handleMicrophoneClick}
+          startIcon={isRecording && speechSupported ? <StopRoundedIcon /> : <MicRoundedIcon />}
+          disabled={isRecording && !speechSupported}
+        >
+          {isRecording && speechSupported ? 'Arrêter' : 'Prononcer la phrase'}
+        </Button>
+        <Button variant="outlined" color="secondary" onClick={handlePlayModel} startIcon={<VolumeUpRoundedIcon />}>
+          Écouter le modèle
+        </Button>
+      </Stack>
+
+      {isRecording && (
+        <Stack spacing={1} alignItems="center">
+          <CircularProgress color="primary" />
+          <Typography variant="body2" color="text.secondary">
+            {speechSupported ? 'Parlez clairement près du micro...' : 'Analyse de votre tentative...'}
+          </Typography>
+        </Stack>
+      )}
+
+      {error && (
+        <Alert severity="warning" icon={<GraphicEqRoundedIcon />}>
+          {error}
+        </Alert>
+      )}
+
+      {result && (
+        <Alert severity={result.isCorrect ? 'success' : 'info'} icon={<GraphicEqRoundedIcon />}>
+          <Stack spacing={1}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+              Transcription détectée
+            </Typography>
+            <Typography variant="body1">{transcript || 'Transcription indisponible'}</Typography>
+            {similarityPercentage !== null && (
+              <Typography variant="body2" color="text.secondary">
+                Similarité : {similarityPercentage}%
+              </Typography>
+            )}
+            <Typography variant="body2" color="text.secondary">
+              {result.isCorrect
+                ? 'Super ! Votre prononciation correspond à la phrase.'
+                : "Bonne tentative ! Continuez à vous entraîner sur l'accent."}
+            </Typography>
+          </Stack>
+        </Alert>
+      )}
+    </Stack>
+  )
+}
+
+export default SpeechRecognitionExercise

--- a/luxembourgish-app/src/data/Unit1Data.ts
+++ b/luxembourgish-app/src/data/Unit1Data.ts
@@ -91,6 +91,29 @@ export const generateUnit1Exercises = (): Exercise[] => {
     context: 'Congé en partant'
   })
 
+  exercises.push({
+    id: 'sentence_building_greeting',
+    type: 'sentence_construction',
+    vocabularyItem: unit1Vocabulary[0],
+    question: 'Assemblez la phrase complète pour dire bonjour et vous présenter.',
+    wordBank: ['Moien', 'ech', 'sinn', 'Léa'].sort(() => Math.random() - 0.5),
+    correctAnswer: 'Moien ech sinn Léa',
+    expectedSentence: 'Moien ech sinn Léa',
+    hint: 'Commencez par la salutation et terminez par votre prénom.',
+    context: 'Présentation simple lors d\'une première rencontre'
+  })
+
+  exercises.push({
+    id: 'speech_recognition_greeting',
+    type: 'speech_recognition',
+    vocabularyItem: unit1Vocabulary[0],
+    question: 'Prononcez la salutation complète « Moien, wéi geet et? »',
+    correctAnswer: 'Moien wéi geet et',
+    expectedSentence: 'Moien wéi geet et',
+    hint: 'Accentuez légèrement « Moien » et liez « geet » et « et ».',
+    context: 'Salutation amicale le matin'
+  })
+
   // Mélanger les exercices pour variété
   return exercises.sort(() => Math.random() - 0.5)
 }

--- a/luxembourgish-app/src/data/Unit2Data.ts
+++ b/luxembourgish-app/src/data/Unit2Data.ts
@@ -91,6 +91,29 @@ export const generateUnit2Exercises = (): Exercise[] => {
     context: 'Structure: Ech sinn vun [lieu] = Je suis de [lieu]'
   })
 
+  exercises.push({
+    id: 'sentence_origin',
+    type: 'sentence_construction',
+    vocabularyItem: unit2Vocabulary[2],
+    question: 'Construisez la phrase pour dire que vous venez du Luxembourg.',
+    wordBank: ['Ech', 'sinn', 'vun', 'Lëtzebuerg'].sort(() => Math.random() - 0.5),
+    correctAnswer: 'Ech sinn vun Lëtzebuerg',
+    expectedSentence: 'Ech sinn vun Lëtzebuerg',
+    hint: 'Placez le verbe « sinn » en deuxième position comme en allemand.',
+    context: 'Présentation de son origine'
+  })
+
+  exercises.push({
+    id: 'speech_recognition_home',
+    type: 'speech_recognition',
+    vocabularyItem: unit2Vocabulary[3],
+    question: 'Prononcez la phrase « Ech wunnen zu Lëtzebuerg » pour dire où vous habitez.',
+    correctAnswer: 'Ech wunnen zu Lëtzebuerg',
+    expectedSentence: 'Ech wunnen zu Lëtzebuerg',
+    hint: 'Prononcez « wunnen » comme « voun-nèn » et adoucissez « Lëtzebuerg ».',
+    context: 'Indiquer son lieu de résidence'
+  })
+
   return exercises.sort(() => Math.random() - 0.5)
 }
 

--- a/luxembourgish-app/src/data/Unit3Data.ts
+++ b/luxembourgish-app/src/data/Unit3Data.ts
@@ -105,6 +105,29 @@ export const generateUnit3Exercises = (): Exercise[] => {
     context: 'Situation: Rencontre formelle avec un adulte inconnu'
   })
 
+  exercises.push({
+    id: 'sentence_question_formal',
+    type: 'sentence_construction',
+    vocabularyItem: unit3Vocabulary[0],
+    question: 'Assemblez la question formelle pour demander le nom de quelqu\'un.',
+    wordBank: ['Wéi', 'heescht', 'Dir'].sort(() => Math.random() - 0.5),
+    correctAnswer: 'Wéi heescht Dir',
+    expectedSentence: 'Wéi heescht Dir',
+    hint: 'Le verbe « heescht » suit immédiatement « Wéi » dans la question.',
+    context: 'Formule de politesse pour s\'adresser à un inconnu'
+  })
+
+  exercises.push({
+    id: 'speech_recognition_question',
+    type: 'speech_recognition',
+    vocabularyItem: unit3Vocabulary[3],
+    question: 'Prononcez la question familière « Wéi heescht du? » pour demander le nom d\'un ami.',
+    correctAnswer: 'Wéi heescht du',
+    expectedSentence: 'Wéi heescht du',
+    hint: 'Adoucissez le « Wéi » (prononcé "vay") et terminez sur un ton montant.',
+    context: 'Question entre amis ou personnes du même âge'
+  })
+
   return exercises.sort(() => Math.random() - 0.5) // Mélange aléatoire final
 }
 

--- a/luxembourgish-app/src/services/SpeechRecognitionService.ts
+++ b/luxembourgish-app/src/services/SpeechRecognitionService.ts
@@ -1,0 +1,175 @@
+export interface StartRecognitionOptions {
+  language?: string
+  interimResults?: boolean
+  continuous?: boolean
+  onStart?: () => void
+  onEnd?: () => void
+  onResult: (transcript: string, event: SpeechRecognitionEvent) => void
+  onError?: (error: string, event: SpeechRecognitionErrorEvent) => void
+}
+
+export class SpeechRecognitionService {
+  private static recognition: SpeechRecognition | null = null
+
+  static isSupported(): boolean {
+    if (typeof window === 'undefined') {
+      return false
+    }
+
+    return Boolean(window.SpeechRecognition || window.webkitSpeechRecognition)
+  }
+
+  static startRecognition(options: StartRecognitionOptions): void {
+    if (!this.isSupported()) {
+      throw new Error('Speech recognition not supported')
+    }
+
+    if (this.recognition) {
+      this.recognition.stop()
+      this.recognition = null
+    }
+
+    const Constructor = window.SpeechRecognition || window.webkitSpeechRecognition
+    const recognition = new Constructor()
+
+    recognition.lang = options.language ?? 'de-DE'
+    recognition.continuous = options.continuous ?? false
+    recognition.interimResults = options.interimResults ?? false
+    recognition.maxAlternatives = 1
+
+    recognition.onstart = () => {
+      options.onStart?.()
+    }
+
+    recognition.onend = () => {
+      options.onEnd?.()
+      this.recognition = null
+    }
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      options.onError?.(event.error, event)
+    }
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const transcript = this.extractTranscript(event)
+      options.onResult(transcript, event)
+    }
+
+    recognition.start()
+    this.recognition = recognition
+  }
+
+  static stopRecognition(): void {
+    if (this.recognition) {
+      this.recognition.stop()
+      this.recognition = null
+    }
+  }
+
+  static abortRecognition(): void {
+    if (this.recognition) {
+      this.recognition.abort()
+      this.recognition = null
+    }
+  }
+
+  static extractTranscript(event: SpeechRecognitionEvent): string {
+    let transcript = ''
+
+    for (let i = event.resultIndex; i < event.results.length; i += 1) {
+      const result = event.results[i]
+      if (result[0]) {
+        transcript += `${result[0].transcript} `
+      }
+    }
+
+    return transcript.trim()
+  }
+
+  static normalizeTranscript(transcript: string): string {
+    return transcript
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[^a-z\s']/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+  }
+
+  static calculateSimilarity(reference: string, actual: string): number {
+    const normalizedReference = this.normalizeTranscript(reference)
+    const normalizedActual = this.normalizeTranscript(actual)
+
+    if (!normalizedReference && !normalizedActual) {
+      return 1
+    }
+
+    const longer = normalizedReference.length >= normalizedActual.length ? normalizedReference : normalizedActual
+    const shorter = longer === normalizedReference ? normalizedActual : normalizedReference
+
+    if (longer.length === 0) {
+      return 1
+    }
+
+    const distance = this.levenshteinDistance(longer, shorter)
+    return (longer.length - distance) / longer.length
+  }
+
+  static scoreTranscript(reference: string, actual: string): { similarity: number; isCorrect: boolean } {
+    const similarity = this.calculateSimilarity(reference, actual)
+    return {
+      similarity,
+      isCorrect: similarity >= 0.65
+    }
+  }
+
+  static simulateRecognition(target: string, onComplete: (transcript: string, similarity: number) => void): void {
+    const normalizedTarget = this.normalizeTranscript(target)
+
+    setTimeout(() => {
+      const simulatedSuccess = Math.random() > 0.35
+      const simulatedTranscript = simulatedSuccess
+        ? target
+        : this.shuffleWords(normalizedTarget)
+
+      const similarity = this.calculateSimilarity(target, simulatedTranscript)
+      onComplete(simulatedTranscript, similarity)
+    }, 1800)
+  }
+
+  private static shuffleWords(sentence: string): string {
+    const words = sentence.split(' ').filter(Boolean)
+    for (let i = words.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[words[i], words[j]] = [words[j], words[i]]
+    }
+    return words.join(' ')
+  }
+
+  private static levenshteinDistance(str1: string, str2: string): number {
+    const matrix: number[][] = []
+
+    for (let i = 0; i <= str2.length; i += 1) {
+      matrix[i] = [i]
+    }
+
+    for (let j = 0; j <= str1.length; j += 1) {
+      matrix[0][j] = j
+    }
+
+    for (let i = 1; i <= str2.length; i += 1) {
+      for (let j = 1; j <= str1.length; j += 1) {
+        if (str2.charAt(i - 1) === str1.charAt(j - 1)) {
+          matrix[i][j] = matrix[i - 1][j - 1]
+        } else {
+          matrix[i][j] = Math.min(
+            matrix[i - 1][j - 1] + 1,
+            matrix[i][j - 1] + 1,
+            matrix[i - 1][j] + 1
+          )
+        }
+      }
+    }
+
+    return matrix[str2.length][str1.length]
+  }
+}

--- a/luxembourgish-app/src/types/LearningTypes.ts
+++ b/luxembourgish-app/src/types/LearningTypes.ts
@@ -19,6 +19,9 @@ export interface Exercise {
   correctAnswer: string
   distractors?: string[]
   context?: string
+  wordBank?: string[]
+  expectedSentence?: string
+  hint?: string
 }
 
 export interface LearningUnit {
@@ -56,6 +59,8 @@ export type ExerciseType =
   | 'translation'          // Traduction français → luxembourgeois
   | 'dialogue_completion'  // Complétion de dialogue
   | 'pronunciation'        // Répétition guidée
+  | 'sentence_construction' // Construction de phrase
+  | 'speech_recognition'    // Répétition + reconnaissance de phrase
 
 export interface UserStats {
   totalXp: number

--- a/luxembourgish-app/src/types/speech-recognition.d.ts
+++ b/luxembourgish-app/src/types/speech-recognition.d.ts
@@ -1,0 +1,58 @@
+export {}
+
+declare global {
+  type SpeechRecognitionConstructor = new () => SpeechRecognition
+
+  interface Window {
+    webkitSpeechRecognition?: SpeechRecognitionConstructor
+    SpeechRecognition?: SpeechRecognitionConstructor
+  }
+
+  interface SpeechGrammarList {}
+
+  interface SpeechRecognitionAlternative {
+    readonly transcript: string
+    readonly confidence: number
+  }
+
+  interface SpeechRecognitionResult extends ArrayLike<SpeechRecognitionAlternative> {
+    readonly isFinal: boolean
+  }
+
+  interface SpeechRecognitionResultList extends ArrayLike<SpeechRecognitionResult> {
+    item(index: number): SpeechRecognitionResult
+    [index: number]: SpeechRecognitionResult
+  }
+
+  interface SpeechRecognition extends EventTarget {
+    lang: string
+    continuous: boolean
+    interimResults: boolean
+    grammars?: SpeechGrammarList
+    onaudioend: ((this: SpeechRecognition, ev: Event) => any) | null
+    onaudiostart: ((this: SpeechRecognition, ev: Event) => any) | null
+    onend: ((this: SpeechRecognition, ev: Event) => any) | null
+    onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => any) | null
+    onnomatch: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => any) | null
+    onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => any) | null
+    onsoundend: ((this: SpeechRecognition, ev: Event) => any) | null
+    onsoundstart: ((this: SpeechRecognition, ev: Event) => any) | null
+    onspeechend: ((this: SpeechRecognition, ev: Event) => any) | null
+    onspeechstart: ((this: SpeechRecognition, ev: Event) => any) | null
+    onstart: ((this: SpeechRecognition, ev: Event) => any) | null
+    maxAlternatives?: number
+    start(): void
+    stop(): void
+    abort(): void
+  }
+
+  interface SpeechRecognitionEvent extends Event {
+    readonly resultIndex: number
+    readonly results: SpeechRecognitionResultList
+  }
+
+  interface SpeechRecognitionErrorEvent extends Event {
+    readonly error: string
+    readonly message: string
+  }
+}


### PR DESCRIPTION
## Summary
- document the plan for sentence construction and speech recognition exercises
- add speech recognition service, reusable components, and type support for the new exercise types
- seed all learning units with sentence construction and speech recognition activities and wire them into the unit flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d185d68d14832885115a0a9ec01c76