### PR TITLE
Fix CI workflow to run from app directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: luxembourgish-app
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -18,6 +21,7 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
+          cache-dependency-path: luxembourgish-app/package-lock.json
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- run npm commands in the luxembourgish-app subdirectory within the CI workflow
- point the Node.js dependency cache to the luxembourgish-app/package-lock.json file so caching works

## Testing
- npm test -- --watchAll=false *(fails: Cannot find module '@testing-library/jest-dom' from 'src/setupTests.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68d196bc658c8328b6e677f95bf1d339