### PR TITLE
Add sentence builder workshop view

### DIFF
--- a/luxembourgish-app/src/App.tsx
+++ b/luxembourgish-app/src/App.tsx
@@ -19,6 +19,7 @@ import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded'
 import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded'
 import AutoAwesomeRoundedIcon from '@mui/icons-material/AutoAwesomeRounded'
 import EmojiEventsRoundedIcon from '@mui/icons-material/EmojiEventsRounded'
+import FormatQuoteRoundedIcon from '@mui/icons-material/FormatQuoteRounded'
 import MenuBookRoundedIcon from '@mui/icons-material/MenuBookRounded'
 import MilitaryTechRoundedIcon from '@mui/icons-material/MilitaryTechRounded'
 import QueryStatsRoundedIcon from '@mui/icons-material/QueryStatsRounded'
@@ -27,12 +28,13 @@ import SchoolRoundedIcon from '@mui/icons-material/SchoolRounded'
 import StarRoundedIcon from '@mui/icons-material/StarRounded'
 import RocketLaunchRoundedIcon from '@mui/icons-material/RocketLaunchRounded'
 import SimpleUnitsList from './components/SimpleUnitsList'
-import VocabularyQuiz from './components/VocabularyQuiz'
 import PhraseList from './components/PhraseList'
+import SentenceBuilderWorkshop from './components/SentenceBuilderWorkshop'
+import VocabularyQuiz from './components/VocabularyQuiz'
 import { UnitProgress, UserStats } from './types/LearningTypes'
 import './NewDesignApp.css'
 
-type View = 'menu' | 'sections' | 'quiz' | 'phrases'
+type View = 'menu' | 'sections' | 'quiz' | 'sentenceBuilder' | 'phrases'
 
 const pageTransition = keyframes`
   from {
@@ -155,6 +157,21 @@ function App() {
         actionIcon: <RocketLaunchRoundedIcon />,
         actionColor: 'warning',
         view: 'quiz' as View
+      },
+      {
+        key: 'sentenceBuilder' as const,
+        title: 'Atelier de phrases',
+        description: 'Entraînez-vous à construire des phrases à partir de bancs de mots guidés.',
+        icon: <FormatQuoteRoundedIcon fontSize="medium" />,
+        accent: 'info',
+        metadata: [
+          { icon: <AutoAwesomeRoundedIcon fontSize="small" />, text: 'Scénarios progressifs' },
+          { icon: <StarRoundedIcon fontSize="small" />, text: 'Feedback immédiat' }
+        ],
+        actionLabel: "Lancer l'atelier",
+        actionIcon: <ArrowForwardRoundedIcon />,
+        actionColor: 'info',
+        view: 'sentenceBuilder' as View
       },
       {
         key: 'phrases' as const,
@@ -315,6 +332,8 @@ function App() {
         )
       case 'quiz':
         return <VocabularyQuiz />
+      case 'sentenceBuilder':
+        return <SentenceBuilderWorkshop />
       case 'phrases':
         return <PhraseList />
       case 'menu':

--- a/luxembourgish-app/src/__tests__/SentenceBuilderWorkshop.test.tsx
+++ b/luxembourgish-app/src/__tests__/SentenceBuilderWorkshop.test.tsx
@@ -1,0 +1,54 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import App from '../App'
+import { sentenceBuilderExercises } from '../data/SentenceBuilderData'
+
+describe('SentenceBuilderWorkshop', () => {
+  it('permet de naviguer et de compléter un atelier de phrases', async () => {
+    jest.useFakeTimers()
+
+    try {
+      render(<App />)
+
+      expect(await screen.findByText('Lëtzebuergesch Léieren')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: "Lancer l'atelier" }))
+
+      expect(await screen.findByText('Atelier de construction de phrases')).toBeInTheDocument()
+      expect(screen.getByText('Scénario 1 sur 3')).toBeInTheDocument()
+
+      for (let index = 0; index < sentenceBuilderExercises.length; index += 1) {
+        const exercise = sentenceBuilderExercises[index]
+        const expectedSentence = exercise.expectedSentence ?? exercise.correctAnswer
+        const tokens = expectedSentence.split(' ')
+
+        tokens.forEach(word => {
+          fireEvent.click(screen.getByRole('button', { name: word }))
+        })
+
+        fireEvent.click(screen.getByRole('button', { name: 'Valider la phrase' }))
+
+        act(() => {
+          jest.advanceTimersByTime(1600)
+        })
+
+        const continueLabel =
+          index === sentenceBuilderExercises.length - 1 ? 'Voir le récapitulatif' : 'Scénario suivant'
+
+        const continueButton = await screen.findByRole('button', { name: continueLabel })
+        fireEvent.click(continueButton)
+      }
+
+      expect(await screen.findByText("Récapitulatif de l'atelier")).toBeInTheDocument()
+      sentenceBuilderExercises.forEach(exercise => {
+        const sentence = exercise.expectedSentence ?? exercise.correctAnswer
+        expect(screen.getByText(sentence)).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: "Recommencer l'atelier" }))
+
+      expect(await screen.findByText('Scénario 1 sur 3')).toBeInTheDocument()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+})

--- a/luxembourgish-app/src/components/SentenceBuilderWorkshop.tsx
+++ b/luxembourgish-app/src/components/SentenceBuilderWorkshop.tsx
@@ -1,0 +1,291 @@
+import { useMemo, useState } from 'react'
+import {
+  Box,
+  Button,
+  Chip,
+  LinearProgress,
+  Stack,
+  Typography
+} from '@mui/material'
+import type { ChipProps } from '@mui/material/Chip'
+import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded'
+import ReplayRoundedIcon from '@mui/icons-material/ReplayRounded'
+import SentenceConstructionExercise from './exercises/SentenceConstructionExercise'
+import { sentenceBuilderExercises } from '../data/SentenceBuilderData'
+
+interface ScenarioResult {
+  exerciseId: string
+  expectedSentence: string
+  isCorrect: boolean
+  attempts: number
+  timeSpent: number
+}
+
+const formatDuration = (durationMs: number): string => {
+  if (durationMs <= 0) {
+    return '0,0 s'
+  }
+
+  const seconds = durationMs / 1000
+  return `${seconds.toFixed(1).replace('.', ',')} s`
+}
+
+const SentenceBuilderWorkshop = () => {
+  const totalScenarios = sentenceBuilderExercises.length
+  const [currentScenarioIndex, setCurrentScenarioIndex] = useState(0)
+  const [scenarioResults, setScenarioResults] = useState<(ScenarioResult | undefined)[]>([])
+  const [latestResult, setLatestResult] = useState<ScenarioResult | null>(null)
+  const [isWorkshopCompleted, setIsWorkshopCompleted] = useState(false)
+
+  const completedCount = useMemo(
+    () => scenarioResults.filter(Boolean).length,
+    [scenarioResults]
+  )
+  const successCount = useMemo(
+    () => scenarioResults.filter(result => result?.isCorrect).length,
+    [scenarioResults]
+  )
+
+  const progressValue = totalScenarios === 0 ? 0 : (completedCount / totalScenarios) * 100
+  const displayProgress = isWorkshopCompleted ? 100 : progressValue
+
+  if (totalScenarios === 0) {
+    return (
+      <Stack spacing={3}>
+        <Typography variant="h3" component="h1">
+          Atelier de construction de phrases
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Les scénarios de construction de phrases seront bientôt disponibles.
+        </Typography>
+      </Stack>
+    )
+  }
+
+  const currentExercise = sentenceBuilderExercises[currentScenarioIndex]
+
+  const handleExerciseComplete = (isCorrect: boolean, timeSpent: number, attempts = 1) => {
+    const summary: ScenarioResult = {
+      exerciseId: currentExercise.id,
+      expectedSentence: currentExercise.expectedSentence ?? currentExercise.correctAnswer,
+      isCorrect,
+      attempts,
+      timeSpent
+    }
+
+    setLatestResult(summary)
+    setScenarioResults(prev => {
+      const updated = [...prev]
+      updated[currentScenarioIndex] = summary
+      return updated
+    })
+  }
+
+  const handleNextScenario = () => {
+    if (currentScenarioIndex >= totalScenarios - 1) {
+      setIsWorkshopCompleted(true)
+    } else {
+      setCurrentScenarioIndex(index => Math.min(index + 1, totalScenarios - 1))
+    }
+
+    setLatestResult(null)
+  }
+
+  const handleRestart = () => {
+    setCurrentScenarioIndex(0)
+    setScenarioResults([])
+    setLatestResult(null)
+    setIsWorkshopCompleted(false)
+  }
+
+  return (
+    <Stack spacing={4}>
+      <Stack spacing={1.5}>
+        <Typography variant="h3" component="h1">
+          Atelier de construction de phrases
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Assemblez les mots proposés pour former des phrases luxembourgeoises correctes et suivez vos progrès scénario après scénario.
+        </Typography>
+      </Stack>
+
+      <Box
+        sx={{
+          p: { xs: 2.5, md: 3 },
+          borderRadius: 3,
+          background: 'linear-gradient(135deg, rgba(25,118,210,0.12) 0%, rgba(20,184,166,0.08) 100%)'
+        }}
+      >
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="subtitle2" color="text.secondary">
+              {isWorkshopCompleted
+                ? 'Atelier terminé'
+                : `Scénario ${currentScenarioIndex + 1} sur ${totalScenarios}`}
+            </Typography>
+            <LinearProgress
+              variant="determinate"
+              value={displayProgress}
+              sx={{
+                mt: 1,
+                height: 10,
+                borderRadius: 999,
+                backgroundColor: 'rgba(255,255,255,0.4)',
+                '& .MuiLinearProgress-bar': { borderRadius: 999 }
+              }}
+            />
+          </Box>
+
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            {sentenceBuilderExercises.map((exercise, index) => {
+              const result = scenarioResults[index]
+              const isCurrent = index === currentScenarioIndex && !isWorkshopCompleted
+              const color: ChipProps['color'] = result
+                ? result.isCorrect
+                  ? 'success'
+                  : 'warning'
+                : isCurrent
+                ? 'primary'
+                : 'default'
+              const variant: ChipProps['variant'] = result || isCurrent ? 'filled' : 'outlined'
+
+              return (
+                <Chip
+                  key={exercise.id}
+                  label={`Scénario ${index + 1}`}
+                  color={color}
+                  variant={variant}
+                  size="small"
+                  sx={{ fontWeight: result ? 600 : 500 }}
+                />
+              )
+            })}
+          </Stack>
+        </Stack>
+      </Box>
+
+      {isWorkshopCompleted ? (
+        <Stack spacing={3}>
+          <Box
+            sx={{
+              p: { xs: 3, md: 4 },
+              borderRadius: 3,
+              background: 'linear-gradient(135deg, rgba(20,184,166,0.12) 0%, rgba(25,118,210,0.05) 100%)'
+            }}
+          >
+            <Stack spacing={1.5}>
+              <Typography variant="h5">Récapitulatif de l'atelier</Typography>
+              <Typography variant="body1">
+                Vous avez correctement reconstitué {successCount} phrase{successCount > 1 ? 's' : ''} sur {totalScenarios}.
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Analysez vos tentatives ci-dessous puis relancez l'atelier pour consolider vos acquis.
+              </Typography>
+            </Stack>
+          </Box>
+
+          <Stack spacing={2}>
+            {sentenceBuilderExercises.map((exercise, index) => {
+              const result = scenarioResults[index]
+              if (!result) {
+                return null
+              }
+
+              return (
+                <Box
+                  key={exercise.id}
+                  sx={{
+                    p: { xs: 2.5, md: 3 },
+                    borderRadius: 3,
+                    border: '1px solid',
+                    borderColor: result.isCorrect ? 'success.light' : 'warning.light',
+                    backgroundColor: result.isCorrect
+                      ? 'rgba(46,125,50,0.08)'
+                      : 'rgba(255,179,0,0.12)'
+                  }}
+                >
+                  <Stack spacing={1}>
+                    <Typography variant="subtitle1">
+                      Scénario {index + 1} · {result.isCorrect ? 'Réussi' : 'À retravailler'}
+                    </Typography>
+                    <Typography variant="body1" sx={{ fontWeight: 600 }}>
+                      {result.expectedSentence}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Tentatives : {result.attempts} · Temps : {formatDuration(result.timeSpent)}
+                    </Typography>
+                  </Stack>
+                </Box>
+              )
+            })}
+          </Stack>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <Button
+              variant="contained"
+              color="primary"
+              startIcon={<ReplayRoundedIcon />}
+              onClick={handleRestart}
+            >
+              Recommencer l'atelier
+            </Button>
+          </Stack>
+        </Stack>
+      ) : (
+        <>
+          <SentenceConstructionExercise
+            key={currentExercise.id}
+            exercise={currentExercise}
+            onComplete={handleExerciseComplete}
+          />
+
+          {latestResult && (
+            <Box
+              sx={{
+                p: { xs: 2.5, md: 3 },
+                borderRadius: 3,
+                backgroundColor: latestResult.isCorrect
+                  ? 'rgba(46,125,50,0.08)'
+                  : 'rgba(239,68,68,0.08)'
+              }}
+            >
+              <Stack
+                direction={{ xs: 'column', md: 'row' }}
+                spacing={2}
+                alignItems={{ xs: 'flex-start', md: 'center' }}
+                justifyContent="space-between"
+              >
+                <Stack spacing={1}>
+                  <Typography variant="subtitle1">
+                    {latestResult.isCorrect
+                      ? 'Bravo ! La phrase est correctement assemblée.'
+                      : 'Observation : analysez la phrase attendue et retentez votre chance.'}
+                  </Typography>
+                  <Typography variant="body1" sx={{ fontWeight: 600 }}>
+                    {latestResult.expectedSentence}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Tentatives : {latestResult.attempts} · Temps : {formatDuration(latestResult.timeSpent)}
+                  </Typography>
+                </Stack>
+
+                <Button
+                  variant="contained"
+                  color="primary"
+                  endIcon={<ArrowForwardRoundedIcon />}
+                  onClick={handleNextScenario}
+                >
+                  {currentScenarioIndex === totalScenarios - 1
+                    ? "Voir le récapitulatif"
+                    : 'Scénario suivant'}
+                </Button>
+              </Stack>
+            </Box>
+          )}
+        </>
+      )}
+    </Stack>
+  )
+}
+
+export default SentenceBuilderWorkshop

--- a/luxembourgish-app/src/data/SentenceBuilderData.ts
+++ b/luxembourgish-app/src/data/SentenceBuilderData.ts
@@ -1,0 +1,55 @@
+import { Exercise } from '../types/LearningTypes'
+
+export const sentenceBuilderExercises: Exercise[] = [
+  {
+    id: 'sentence_builder_1',
+    type: 'sentence_construction',
+    vocabularyItem: {
+      id: 'sentence_builder_vocab_1',
+      luxembourgish: "Ech ginn an d'Schoul",
+      french: "Je vais à l'école",
+      pronunciation: "Ekh ginn an d'Shoul",
+      usage: 'Exprimer un déplacement vers un lieu du quotidien'
+    },
+    question: 'Assemblez la phrase luxembourgeoise correspondant à « Je vais à l\'école ».',
+    correctAnswer: "Ech ginn an d'Schoul",
+    expectedSentence: "Ech ginn an d'Schoul",
+    wordBank: ['Ech', 'ginn', 'an', "d'Schoul"],
+    hint: 'Commencez par le pronom sujet « Ech » avant le verbe.',
+    context: 'Structure simple sujet + verbe + complément.'
+  },
+  {
+    id: 'sentence_builder_2',
+    type: 'sentence_construction',
+    vocabularyItem: {
+      id: 'sentence_builder_vocab_2',
+      luxembourgish: "D'Kanner spillen am Park",
+      french: 'Les enfants jouent au parc',
+      pronunciation: "D'Kanner shpillen am Park",
+      usage: 'Décrire une activité d\'enfants dans un lieu public'
+    },
+    question: 'Reconstituez la phrase signifiant « Les enfants jouent au parc ».',
+    correctAnswer: "D'Kanner spillen am Park",
+    expectedSentence: "D'Kanner spillen am Park",
+    wordBank: ["D'Kanner", 'spillen', 'am', 'Park'],
+    hint: 'Commencez par le groupe nominal « D\'Kanner » pour exprimer le sujet.',
+    context: 'Pensez au verbe « spillen » qui signifie jouer.'
+  },
+  {
+    id: 'sentence_builder_3',
+    type: 'sentence_construction',
+    vocabularyItem: {
+      id: 'sentence_builder_vocab_3',
+      luxembourgish: 'Mir drénken gär moies Kaffi',
+      french: 'Nous aimons boire du café le matin',
+      pronunciation: 'Meer drengken gair moy-es Kaffi',
+      usage: 'Parler des habitudes quotidiennes en famille ou entre amis'
+    },
+    question: 'Construisez la phrase équivalente à « Nous aimons boire du café le matin ».',
+    correctAnswer: 'Mir drénken gär moies Kaffi',
+    expectedSentence: 'Mir drénken gär moies Kaffi',
+    wordBank: ['Mir', 'drénken', 'gär', 'moies', 'Kaffi'],
+    hint: 'Le verbe « drénken » (boire) est suivi de l\'adverbe « gär » pour exprimer le plaisir.',
+    context: 'L\'adverbe « moies » précise le moment de la journée.'
+  }
+]


### PR DESCRIPTION
## Summary
- add a SentenceBuilderData source that defines three sentence construction scenarios
- build a SentenceBuilderWorkshop component that sequences the exercises and displays a completion summary
- wire the new workshop into the main application menu and cover the flow with a dedicated test

## Testing
- CI=1 npm test -- SentenceBuilderWorkshop.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d2cd2ee6108328b06447cd5b163592