### PR TITLE
Improve Luxembourgish speech synthesis support

### DIFF
--- a/luxembourgish-app/src/__tests__/AudioService.test.ts
+++ b/luxembourgish-app/src/__tests__/AudioService.test.ts
@@ -40,11 +40,58 @@ class MockAudioContext {
   })
 }
 
+const createVoice = (lang: string, name: string = lang): SpeechSynthesisVoice =>
+  ({
+    default: false,
+    lang,
+    localService: true,
+    name,
+    voiceURI: name
+  } as SpeechSynthesisVoice)
+
+class MockSpeechSynthesis {
+  voices: SpeechSynthesisVoice[] = []
+
+  utterances: SpeechSynthesisUtterance[] = []
+
+  onvoiceschanged: (() => void) | null = null
+
+  private listeners: Map<string, Set<() => void>> = new Map()
+
+  speak = jest.fn((utterance: SpeechSynthesisUtterance) => {
+    this.utterances.push(utterance)
+    utterance.onend?.(new Event('end'))
+  })
+
+  cancel = jest.fn()
+
+  getVoices = jest.fn(() => this.voices)
+
+  addEventListener = jest.fn((event: string, handler: () => void) => {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set())
+    }
+    this.listeners.get(event)!.add(handler)
+  })
+
+  removeEventListener = jest.fn((event: string, handler: () => void) => {
+    this.listeners.get(event)?.delete(handler)
+  })
+
+  dispatch(event: string) {
+    this.listeners.get(event)?.forEach(listener => listener())
+    if (event === 'voiceschanged' && this.onvoiceschanged) {
+      this.onvoiceschanged.call(this as unknown as SpeechSynthesis)
+    }
+  }
+}
+
 describe('AudioService', () => {
   let originalAudioContext: typeof AudioContext | undefined
   let originalSpeechSynthesis: SpeechSynthesis | undefined
   let originalSpeechSynthesisUtterance: typeof SpeechSynthesisUtterance | undefined
   let mockContext: MockAudioContext
+  let mockSpeechSynthesis: MockSpeechSynthesis
 
   const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0))
 
@@ -60,11 +107,11 @@ describe('AudioService', () => {
 
     ;(AudioService as any).audioContext = null
     ;(AudioService as any).speechSynth = null
+    ;(AudioService as any).preferredVoice = null
+    ;(AudioService as any).voiceResolution = null
 
-    window.speechSynthesis = {
-      speak: jest.fn(),
-      cancel: jest.fn()
-    } as unknown as SpeechSynthesis
+    mockSpeechSynthesis = new MockSpeechSynthesis()
+    window.speechSynthesis = mockSpeechSynthesis as unknown as SpeechSynthesis
 
     ;(window as any).SpeechSynthesisUtterance = jest.fn(function (this: any, text: string) {
       this.text = text
@@ -72,6 +119,7 @@ describe('AudioService', () => {
       this.rate = 1
       this.pitch = 1
       this.volume = 1
+      this.voice = null
       this.onend = null
       this.onerror = null
     })
@@ -143,26 +191,121 @@ describe('AudioService', () => {
     expect(progressSpy).toHaveBeenCalled()
   })
 
-  it('speaks luxembourgish text and resolves when finished', async () => {
+  it('speaks luxembourgish text using selected voice and corrections', async () => {
+    const luxVoice = createVoice('lb-LU', 'Lux Voice')
+    mockSpeechSynthesis.voices = [luxVoice]
+
+    await expect(
+      AudioService.speakLuxembourgish("Moien D’Frënd", 0.6, 1.2)
+    ).resolves.toBeUndefined()
+
+    expect(mockSpeechSynthesis.speak).toHaveBeenCalledTimes(1)
+    const utterance = (mockSpeechSynthesis.speak as jest.Mock).mock.calls[0][0] as SpeechSynthesisUtterance
+    expect(utterance.voice).toBe(luxVoice)
+    expect(utterance.lang).toBe('lb-LU')
+    expect(utterance.text).toBe('Moien De Frend')
+    expect(utterance.rate).toBe(0.6)
+    expect(utterance.pitch).toBe(1.2)
+    expect(utterance.volume).toBe(0.8)
+  })
+
+  it('waits for luxembourgish voices when they load asynchronously', async () => {
+    mockSpeechSynthesis.voices = []
+
+    const speakPromise = AudioService.speakLuxembourgish('Salut')
+    await Promise.resolve()
+
+    const germanVoice = createVoice('de-DE', 'German Voice')
+    const luxVoice = createVoice('lb-LU', 'Lux Voice')
+    mockSpeechSynthesis.voices = [germanVoice, luxVoice]
+    mockSpeechSynthesis.dispatch('voiceschanged')
+
+    await speakPromise
+
+    const utterance = (mockSpeechSynthesis.speak as jest.Mock).mock.calls[0][0] as SpeechSynthesisUtterance
+    expect(utterance.voice).toBe(luxVoice)
+    expect(utterance.lang).toBe('lb-LU')
+  })
+
+  it('falls back to de-LU voice when luxembourgish is unavailable', async () => {
+    const fallbackVoice = createVoice('de-LU', 'German Luxembourgish')
+    mockSpeechSynthesis.voices = [fallbackVoice]
+
+    await AudioService.speakLuxembourgish('Moien')
+
+    const utterance = (mockSpeechSynthesis.speak as jest.Mock).mock.calls[0][0] as SpeechSynthesisUtterance
+    expect(utterance.voice).toBe(fallbackVoice)
+    expect(utterance.lang).toBe('de-LU')
+  })
+
+  it('falls back to de-DE voice when no localized voice is available', async () => {
+    const germanVoice = createVoice('de-DE', 'German Voice')
+    mockSpeechSynthesis.voices = [germanVoice]
+
+    await AudioService.speakLuxembourgish('Moien')
+
+    const utterance = (mockSpeechSynthesis.speak as jest.Mock).mock.calls[0][0] as SpeechSynthesisUtterance
+    expect(utterance.voice).toBe(germanVoice)
+    expect(utterance.lang).toBe('de-DE')
+  })
+
+  it('handles speech synthesis without voice support gracefully', async () => {
     const speakMock = jest.fn((utterance: SpeechSynthesisUtterance) => {
-      if (utterance.onend) {
-        utterance.onend(new Event('end'))
-      }
+      utterance.onend?.(new Event('end'))
     })
-    window.speechSynthesis = {
+    const fallbackSynthesis = {
       speak: speakMock,
       cancel: jest.fn()
     } as unknown as SpeechSynthesis
 
-    await expect(AudioService.speakLuxembourgish('Moien')).resolves.toBeUndefined()
-    expect(speakMock).toHaveBeenCalled()
-    const utterance = speakMock.mock.calls[0][0]
-    expect(utterance.lang).toBe('de-DE')
-    expect(utterance.rate).toBe(0.7)
+    const previousSynth = window.speechSynthesis
+    window.speechSynthesis = fallbackSynthesis
+    ;(AudioService as any).speechSynth = null
+    ;(AudioService as any).preferredVoice = null
+    ;(AudioService as any).voiceResolution = null
+
+    try {
+      await expect(AudioService.speakLuxembourgish('Moien')).resolves.toBeUndefined()
+      const utterance = speakMock.mock.calls[0][0] as SpeechSynthesisUtterance
+      expect(utterance.voice).toBeNull()
+      expect(utterance.lang).toBe('de-DE')
+    } finally {
+      window.speechSynthesis = previousSynth
+      ;(AudioService as any).speechSynth = null
+      ;(AudioService as any).preferredVoice = null
+      ;(AudioService as any).voiceResolution = null
+    }
+  })
+
+  it('allows overriding rate and pitch per phrase', async () => {
+    const germanVoice = createVoice('de-DE', 'German Voice')
+    mockSpeechSynthesis.voices = [germanVoice]
+
+    await AudioService.speakLuxembourgish(
+      [
+        { text: 'Moien', rate: 0.6 },
+        { text: 'Wéi geet et?', pitch: 1.3 }
+      ],
+      0.8,
+      1.1
+    )
+
+    expect(mockSpeechSynthesis.speak).toHaveBeenCalledTimes(2)
+    const firstUtterance = (mockSpeechSynthesis.speak as jest.Mock).mock.calls[0][0] as SpeechSynthesisUtterance
+    const secondUtterance = (mockSpeechSynthesis.speak as jest.Mock).mock.calls[1][0] as SpeechSynthesisUtterance
+
+    expect(firstUtterance.voice).toBe(germanVoice)
+    expect(firstUtterance.rate).toBe(0.6)
+    expect(firstUtterance.pitch).toBe(1.1)
+    expect(secondUtterance.rate).toBe(0.8)
+    expect(secondUtterance.pitch).toBe(1.3)
   })
 
   it('rejects when speech synthesis is unavailable', async () => {
     delete (window as any).speechSynthesis
+    ;(AudioService as any).speechSynth = null
+    ;(AudioService as any).preferredVoice = null
+    ;(AudioService as any).voiceResolution = null
 
     await expect(AudioService.speakLuxembourgish('Moien')).rejects.toThrow('Speech synthesis not supported')
   })

--- a/luxembourgish-app/src/services/AudioService.ts
+++ b/luxembourgish-app/src/services/AudioService.ts
@@ -4,6 +4,39 @@
 export class AudioService {
   private static audioContext: AudioContext | null = null
   private static speechSynth: SpeechSynthesis | null = null
+  private static preferredVoice: SpeechSynthesisVoice | null = null
+  private static voiceResolution: Promise<SpeechSynthesisVoice | null> | null = null
+
+  private static readonly correctionRules: Array<
+    [RegExp, string | ((substring: string, ...args: any[]) => string)]
+  > = [
+    [/['’‘`]/g, "'"],
+    [
+      /\b([dtns])'(?=\w)/gi,
+      (_match: string, letter: string) => {
+        const replacements: Record<string, string> = {
+          d: 'de ',
+          t: 'te ',
+          n: 'en ',
+          s: 'se '
+        }
+        const replacement = replacements[letter.toLowerCase()] ?? ''
+        if (!replacement) {
+          return replacement
+        }
+        return letter === letter.toUpperCase()
+          ? replacement.charAt(0).toUpperCase() + replacement.slice(1)
+          : replacement
+      }
+    ],
+    [/[äâáà]/gi, 'a'],
+    [/[ëêéè]/gi, 'e'],
+    [/[ïîíì]/gi, 'i'],
+    [/[öôóò]/gi, 'o'],
+    [/[üûúù]/gi, 'u'],
+    [/ß/g, 'ss'],
+    [/ç/g, 'c']
+  ]
 
   // Initialisation du contexte audio
   private static getAudioContext(): AudioContext {
@@ -11,6 +44,134 @@ export class AudioService {
       this.audioContext = new (window.AudioContext || (window as any).webkitAudioContext)()
     }
     return this.audioContext
+  }
+
+  private static getSpeechSynth(): SpeechSynthesis {
+    if (!this.speechSynth) {
+      this.speechSynth = window.speechSynthesis
+    }
+    return this.speechSynth
+  }
+
+  private static async getPreferredVoice(): Promise<SpeechSynthesisVoice | null> {
+    if (this.preferredVoice) {
+      return this.preferredVoice
+    }
+
+    if (this.voiceResolution) {
+      return this.voiceResolution
+    }
+
+    this.voiceResolution = (async () => {
+      const synth = this.getSpeechSynth()
+      if (!synth || typeof synth.getVoices !== 'function') {
+        return null
+      }
+
+      const voices = await this.waitForVoices(synth)
+      const selected = this.selectPreferredVoice(voices)
+      if (selected) {
+        this.preferredVoice = selected
+      }
+      return selected
+    })()
+
+    try {
+      return await this.voiceResolution
+    } finally {
+      this.voiceResolution = null
+    }
+  }
+
+  private static async waitForVoices(
+    synth: SpeechSynthesis
+  ): Promise<SpeechSynthesisVoice[]> {
+    const existingVoices = synth.getVoices()
+    if (existingVoices.length > 0) {
+      return existingVoices
+    }
+
+    return new Promise(resolve => {
+      const synthAny = synth as unknown as {
+        onvoiceschanged?: (() => void) | null
+      }
+
+      let resolved = false
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+      const cleanup = () => {
+        if (typeof synth.removeEventListener === 'function') {
+          synth.removeEventListener('voiceschanged', handleVoicesChanged)
+        }
+        if (synthAny && 'onvoiceschanged' in synthAny) {
+          synthAny.onvoiceschanged = null
+        }
+        if (timeoutId) {
+          clearTimeout(timeoutId)
+        }
+      }
+
+      const handleVoicesChanged = () => {
+        if (resolved) {
+          return
+        }
+        const availableVoices = synth.getVoices()
+        if (availableVoices.length > 0) {
+          resolved = true
+          cleanup()
+          resolve(availableVoices)
+        }
+      }
+
+      if (typeof synth.addEventListener === 'function') {
+        synth.addEventListener('voiceschanged', handleVoicesChanged)
+      } else if (synthAny) {
+        synthAny.onvoiceschanged = handleVoicesChanged
+      }
+
+      timeoutId = setTimeout(() => {
+        if (!resolved) {
+          resolved = true
+          cleanup()
+          resolve([])
+        }
+      }, 1000)
+    })
+  }
+
+  private static selectPreferredVoice(
+    voices: SpeechSynthesisVoice[]
+  ): SpeechSynthesisVoice | null {
+    if (!voices.length) {
+      return null
+    }
+
+    const normalizeLang = (lang?: string) => lang?.toLowerCase() ?? ''
+    const findByLang = (lang: string) =>
+      voices.find(voice => normalizeLang(voice.lang) === lang) ?? null
+
+    return (
+      findByLang('lb-lu') ||
+      findByLang('lb') ||
+      findByLang('de-lu') ||
+      findByLang('de-de') ||
+      voices[0] ||
+      null
+    )
+  }
+
+  private static applyTextCorrections(text: string): string {
+    let normalized = text
+
+    for (const [pattern, replacement] of this.correctionRules) {
+      if (typeof replacement === 'string') {
+        normalized = normalized.replace(pattern, replacement)
+      } else {
+        normalized = normalized.replace(pattern, replacement as any)
+      }
+    }
+
+    return normalized.replace(/\s{2,}/g, ' ').trim()
   }
 
   // Sons de transition et feedback
@@ -129,26 +290,45 @@ export class AudioService {
   }
 
   // Prononciation des mots luxembourgeois
-  static speakLuxembourgish(text: string, rate: number = 0.7): Promise<void> {
-    return new Promise((resolve, reject) => {
-      if (!('speechSynthesis' in window)) {
-        reject(new Error('Speech synthesis not supported'))
-        return
-      }
+  static async speakLuxembourgish(
+    content: string | Array<{ text: string; rate?: number; pitch?: number }>,
+    defaultRate: number = 0.7,
+    defaultPitch: number = 1.0
+  ): Promise<void> {
+    if (!('speechSynthesis' in window) || !window.speechSynthesis) {
+      throw new Error('Speech synthesis not supported')
+    }
 
-      const utterance = new SpeechSynthesisUtterance(text)
+    const phrases = Array.isArray(content)
+      ? content
+      : [{ text: content, rate: defaultRate, pitch: defaultPitch }]
 
-      // Configuration pour le luxembourgeois (utilise l'allemand comme approximation)
-      utterance.lang = 'de-DE'
-      utterance.rate = rate
-      utterance.pitch = 1.0
+    const synth = this.getSpeechSynth()
+    const voice = await this.getPreferredVoice()
+
+    for (const phrase of phrases) {
+      const utterance = new SpeechSynthesisUtterance(
+        this.applyTextCorrections(phrase.text)
+      )
+
+      utterance.lang = voice?.lang ?? 'de-DE'
+      utterance.voice = voice ?? null
+      utterance.rate = phrase.rate ?? defaultRate
+      utterance.pitch = phrase.pitch ?? defaultPitch
       utterance.volume = 0.8
 
-      utterance.onend = () => resolve()
-      utterance.onerror = (event) => reject(event.error)
+      await new Promise<void>((resolve, reject) => {
+        utterance.onend = () => resolve()
+        utterance.onerror = (event) =>
+          reject(
+            event?.error
+              ? new Error(String(event.error))
+              : new Error('Speech synthesis failed')
+          )
 
-      speechSynthesis.speak(utterance)
-    })
+        synth.speak(utterance)
+      })
+    }
   }
 
   // Prononciation avec bouton visuel

--- a/luxembourgish-app/src/setupTests.ts
+++ b/luxembourgish-app/src/setupTests.ts
@@ -25,7 +25,11 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
 if (typeof window !== 'undefined' && !('speechSynthesis' in window)) {
   ;(window as any).speechSynthesis = {
     speak: jest.fn(),
-    cancel: jest.fn()
+    cancel: jest.fn(),
+    getVoices: jest.fn(() => []),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    onvoiceschanged: null
   }
 }
 
@@ -36,6 +40,7 @@ if (typeof window !== 'undefined' && typeof (window as any).SpeechSynthesisUtter
     this.rate = 1
     this.pitch = 1
     this.volume = 1
+    this.voice = null
     this.onend = null
     this.onerror = null
   }


### PR DESCRIPTION
## Summary
- initialize and cache the speech synthesis engine once, wait for voice availability, and prefer Luxembourgish voices with German fallbacks
- normalize Luxembourgish text before speaking and support per-phrase rate and pitch overrides
- expand audio service tests to cover voice selection flows and update the Jest setup speech synthesis mocks

## Testing
- CI=true npm test -- --runTestsByPath src/__tests__/AudioService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d2cd36003c83288d7093026005c4d1