### PR TITLE
refactor: centralize unit data and fix level typing

### DIFF
--- a/CONSTRUCTION_RESUME.md
+++ b/CONSTRUCTION_RESUME.md
@@ -198,6 +198,14 @@ export type ExerciseType =
 1. **Finaliser Unit4NewData.ts** (Temps et jours)
 2. **Créer Units 5-8** pour compléter Section 1
 3. **Implémenter composants React** pour navigation multi-sections
+
+### 🧹 PLAN DE NETTOYAGE DES DONNÉES D'UNITÉS
+
+- ✅ **Centraliser les imports** des unités via `src/data/unitSections.ts` pour éviter les références directes aux fichiers `*NewData.ts`.
+- 🔄 **Renommer progressivement** les fichiers `UnitXNewData.ts` en `UnitXData.ts` une fois les anciennes versions archivées.
+- 🔄 **Mettre à jour les imports** restants vers la nouvelle convention afin d'éliminer toute occurrence de `New` dans le code applicatif.
+- 🔄 **Ajouter un script de validation** (ex: `npm run validate:units`) pour vérifier la conformité des structures `LearningUnit` et du niveau CECR (`CEFRLevel`).
+- 🔄 **Documenter la structure** des unités (schéma de données, conventions de nommage) dans un guide dédié pour faciliter les contributions futures.
 4. **Tests et validation** progression pédagogique
 5. **Déploiement thème dark** et UX mobile
 

--- a/INTEGRATION_TEST.md
+++ b/INTEGRATION_TEST.md
@@ -3,8 +3,8 @@
 ## ✅ TESTS RÉALISÉS
 
 ### **1. INTÉGRATION DES NOUVELLES UNITÉS**
-- ✅ **LearningPathData.ts** - Imports mis à jour vers nouvelles unités
-- ✅ **SimpleUnitsList.tsx** - Références mises à jour vers Unit3NewData, Unit4NewData, Unit5NewData
+- ✅ **LearningPathData.ts** - Génération dynamique via `unitSections`
+- ✅ **SimpleUnitsList.tsx** - Sections centralisées depuis `unitSections`
 - ✅ **Descriptions sections** - Adaptées au contenu des nouvelles unités
 
 ### **2. INTÉGRATION THÈME DARK**
@@ -96,7 +96,7 @@
 ## ⚠️ POINTS D'ATTENTION
 
 ### **DÉPENDANCES**
-- Vérifier que tous les fichiers `*NewData.ts` sont accessibles
+- Vérifier que la centralisation `unitSections.ts` couvre toutes les unités nécessaires
 - Confirmer que `useConfirmAction` hook fonctionne correctement
 - Valider que `theme-dark.ts` et `mobile-optimized.css` sont chargés
 

--- a/src/components/SimpleUnitsList.tsx
+++ b/src/components/SimpleUnitsList.tsx
@@ -1,12 +1,7 @@
 import React, { useState } from 'react'
-import { UnitProgress } from '../types/LearningTypes'
+import type { LearningUnit, UnitProgress } from '../types/LearningTypes'
 import '../styles/SimpleUnitsList.css'
-import { learningUnit1 } from '../data/Unit1Data'
-import { learningUnit2 } from '../data/Unit2Data'
-import { learningUnit3 } from '../data/Unit3NewData'
-import { learningUnit4 } from '../data/Unit4NewData'
-import { learningUnit5 } from '../data/Unit5NewData'
-import { learningUnit6 } from '../data/Unit6Data'
+import { beginnerUnitSections } from '../data/unitSections'
 import LearningUnit from './LearningUnit'
 
 interface SimpleUnitsListProps {
@@ -15,40 +10,20 @@ interface SimpleUnitsListProps {
 }
 
 const SimpleUnitsList: React.FC<SimpleUnitsListProps> = ({ onBack, onUnitComplete }) => {
-  const [currentUnit, setCurrentUnit] = useState<any>(null)
+  const [currentUnit, setCurrentUnit] = useState<LearningUnit | null>(null)
   const [completedUnits, setCompletedUnits] = useState<string[]>([])
 
-  const sections = [
-    {
-      id: 'section1',
-      title: 'Premiers pas',
-      description: 'Découvrez les bases du luxembourgeois',
-      color: '#4ade80',
-      units: [learningUnit1, learningUnit2]
-    },
-    {
-      id: 'section2',
-      title: 'Nombres et temps',
-      description: 'Maîtrisez les nombres, le temps et les jours',
-      color: '#3b82f6',
-      units: [learningUnit3, learningUnit4]
-    },
-    {
-      id: 'section3',
-      title: 'Famille et relations',
-      description: 'Parlez de votre famille avec les possessifs',
-      color: '#8b5cf6',
-      units: [learningUnit5, learningUnit6]
-    }
-  ]
+  const sections = beginnerUnitSections
 
-  const handleUnitClick = (unit: any) => {
+  const handleUnitClick = (unit: LearningUnit) => {
     setCurrentUnit(unit)
   }
 
   const handleUnitComplete = (progress: UnitProgress) => {
     if (progress.isCompleted && currentUnit) {
-      setCompletedUnits(prev => [...prev, currentUnit.id])
+      setCompletedUnits(prev =>
+        prev.includes(currentUnit.id) ? prev : [...prev, currentUnit.id]
+      )
       onUnitComplete(progress)
     }
     setCurrentUnit(null)

--- a/src/data/LearningPathData.ts
+++ b/src/data/LearningPathData.ts
@@ -1,91 +1,52 @@
 // Données du parcours d'apprentissage à la Duolingo
 
 import { PathSection, PathNode, LearningState } from '../types/LearningTypes'
-import { learningUnit1 } from './Unit1Data'
-import { learningUnit2 } from './Unit2Data'
-import { learningUnit3 } from './Unit3NewData'
-import { learningUnit4 } from './Unit4NewData'
-import { learningUnit5 } from './Unit5NewData'
-import { learningUnit6 } from './Unit6Data'
+import { beginnerUnitSections } from './unitSections'
 
 // Configuration du parcours avec positions visuelles
-export const learningPathSections: PathSection[] = [
-  {
-    id: 'section_1',
-    title: 'Premiers pas',
-    description: 'Découvrez les bases du luxembourgeois',
-    color: '#4ade80', // vert clair
-    order: 1,
-    nodes: [
-      {
-        id: 'node_1',
-        unit: learningUnit1,
-        position: { x: 50, y: 20 },
-        isUnlocked: true,  // Premier nœud toujours débloqué
-        isCompleted: false,
-        sectionId: 'section_1'
-      },
-      {
-        id: 'node_2',
-        unit: learningUnit2,
-        position: { x: 50, y: 40 },
-        isUnlocked: false,
-        isCompleted: false,
-        sectionId: 'section_1'
-      }
-    ]
-  },
-  {
-    id: 'section_2',
-    title: 'Nombres et temps',
-    description: 'Maîtrisez les nombres, le temps et les jours',
-    color: '#3b82f6', // bleu
-    order: 2,
-    nodes: [
-      {
-        id: 'node_3',
-        unit: learningUnit3,
-        position: { x: 30, y: 60 },
-        isUnlocked: false,
-        isCompleted: false,
-        sectionId: 'section_2'
-      },
-      {
-        id: 'node_4',
-        unit: learningUnit4,
-        position: { x: 70, y: 75 },
-        isUnlocked: false,
-        isCompleted: false,
-        sectionId: 'section_2'
-      }
-    ]
-  },
-  {
-    id: 'section_3',
-    title: 'Famille et relations',
-    description: 'Parlez de votre famille avec les possessifs',
-    color: '#8b5cf6', // violet
-    order: 3,
-    nodes: [
-      {
-        id: 'node_5',
-        unit: learningUnit5,
-        position: { x: 40, y: 90 },
-        isUnlocked: false,
-        isCompleted: false,
-        sectionId: 'section_3'
-      },
-      {
-        id: 'node_6',
-        unit: learningUnit6,
-        position: { x: 60, y: 105 },
-        isUnlocked: false,
-        isCompleted: false,
-        sectionId: 'section_3'
-      }
-    ]
+const getFallbackPosition = (index: number): PathNode['position'] => {
+  const column = index % 2 === 0 ? 40 : 60
+  const row = Math.floor(index / 2)
+
+  return {
+    x: column,
+    y: 20 + row * 20
   }
-]
+}
+
+const createLearningPathSections = (): PathSection[] => {
+  let nodeIndex = 0
+
+  return beginnerUnitSections.map(section => {
+    const nodes = section.units.map((unit, unitPositionIndex) => {
+      const position = section.pathLayout?.[unitPositionIndex] ?? getFallbackPosition(nodeIndex)
+      const nodeId = `node_${nodeIndex + 1}`
+
+      const node: PathNode = {
+        id: nodeId,
+        unit,
+        position,
+        isUnlocked: nodeId === 'node_1',
+        isCompleted: false,
+        sectionId: section.id
+      }
+
+      nodeIndex += 1
+      return node
+    })
+
+    return {
+      id: section.id,
+      title: section.title,
+      description: section.description,
+      color: section.color,
+      nodes,
+      order: section.order
+    }
+  })
+}
+
+export const learningPathSections: PathSection[] = createLearningPathSections()
 
 // État initial du parcours d'apprentissage
 export const initialLearningState: LearningState = {

--- a/src/data/unitSections.ts
+++ b/src/data/unitSections.ts
@@ -1,0 +1,51 @@
+import type { UnitSection } from '../types/LearningTypes'
+import { learningUnit1 } from './Unit1Data'
+import { learningUnit2 } from './Unit2Data'
+import { learningUnit3 as learningUnitNumbers } from './Unit3NewData'
+import { learningUnit4 as learningUnitTime } from './Unit4NewData'
+import { learningUnit5 as learningUnitFamily } from './Unit5NewData'
+import { learningUnit6 } from './Unit6Data'
+
+export const beginnerUnitSections: UnitSection[] = [
+  {
+    id: 'section_1',
+    title: 'Premiers pas',
+    description: 'Découvrez les bases du luxembourgeois',
+    color: '#4ade80',
+    order: 1,
+    units: [learningUnit1, learningUnit2],
+    pathLayout: [
+      { x: 50, y: 20 },
+      { x: 50, y: 40 }
+    ]
+  },
+  {
+    id: 'section_2',
+    title: 'Nombres et temps',
+    description: 'Maîtrisez les nombres, le temps et les jours',
+    color: '#3b82f6',
+    order: 2,
+    units: [learningUnitNumbers, learningUnitTime],
+    pathLayout: [
+      { x: 30, y: 60 },
+      { x: 70, y: 75 }
+    ]
+  },
+  {
+    id: 'section_3',
+    title: 'Famille et relations',
+    description: 'Parlez de votre famille avec les possessifs',
+    color: '#8b5cf6',
+    order: 3,
+    units: [learningUnitFamily, learningUnit6],
+    pathLayout: [
+      { x: 40, y: 90 },
+      { x: 60, y: 105 }
+    ]
+  }
+]
+
+export const beginnerUnits = beginnerUnitSections.flatMap(section => section.units)
+
+export const getBeginnerUnitById = (unitId: string) =>
+  beginnerUnits.find(unit => unit.id === unitId)

--- a/src/types/LearningTypes.ts
+++ b/src/types/LearningTypes.ts
@@ -24,15 +24,34 @@ export interface Exercise {
   hint?: string
 }
 
+export type CEFRLevel =
+  | 'A1'
+  | 'A1+'
+  | 'A2'
+  | 'A2+'
+  | 'B1'
+  | 'B1+'
+  | 'B2'
+
 export interface LearningUnit {
   id: string
   title: string
   description: string
-  level: 'A1' | 'A2' | 'B1' | 'B2'
+  level: CEFRLevel
   vocabulary: VocabularyItem[]
   exercises: Exercise[]
   targetScore: number
   estimatedTime: number // en minutes
+}
+
+export interface UnitSection {
+  id: string
+  title: string
+  description: string
+  color: string
+  order: number
+  units: LearningUnit[]
+  pathLayout?: Array<{ x: number; y: number }>
 }
 
 export interface ExerciseResult {


### PR DESCRIPTION
## Summary
- extend the `LearningUnit` model with a CEFR level union and a reusable `UnitSection` contract
- centralize beginner unit exports in `src/data/unitSections.ts` and update the learning path plus unit list to consume it
- document the unit data cleanup plan and refresh integration notes to reflect the new structure

## Testing
- ./node_modules/.bin/tsc --noEmit *(fails: `/usr/bin/env: ‘node’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68d38992694c8328af0ab27bdc1ad413