### PR TITLE
Add AGENTS guidelines for repository and data directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Directives pour les contributrices et contributeurs de Lëtz Learn
+
+Bienvenue dans le dépôt de l'application **Lëtzebuergesch Léieren**. Ce document établit des règles transverses qui s'appliquent à l'ensemble du dépôt.
+
+## 1. Gouvernance de produit (vision chef·fe de projet)
+- Avant toute évolution fonctionnelle, consultez `CHEF_PROJET_ROADMAP.md`, `Architecture-Analysis-48-Units.md` et `CONSTRUCTION_RESUME.md` pour vérifier l'alignement stratégique.
+- Documentez toute fonctionnalité livrée ou retirée dans `README-APP.md` et mettez à jour les diagrammes ou notes d'architecture concernées.
+- Maintenez la cohérence des parcours pédagogiques : si une unité change, revoyez les dépendances et l'impact sur les tests end-to-end.
+
+## 2. Qualité linguistique (voix de linguiste luxembourgeois·e)
+- Les textes destinés aux apprenant·e·s doivent être d'abord en luxembourgeois correct (avec tréma/umlaut : ä, ë, é, ï, etc.), puis accompagnés d'explications françaises ou phonétiques.
+- Respectez le registre attendu par niveau CECRL (A1 → phrases simples, B1 → nuances). Toute nouvelle phrase doit indiquer un usage clair et culturellement pertinent.
+- Vérifiez systématiquement la justesse linguistique : orthographe, casse, ponctuation et grammaire luxembourgeoise.
+
+## 3. Principes de conception et de développement
+- Le projet utilise React 18 + TypeScript + Material UI. Privilégiez des composants fonctionnels typés et respectez la structure de dossiers actuelle (`components`, `data`, `hooks`, `services`, etc.).
+- Mettez à jour ou créez les types dans `src/types` avant d'introduire une nouvelle forme de données ou d'exercice.
+- Visez l'accessibilité : aria-labels pertinents, contrastes suffisants, interactions clavier testées.
+- Les chaînes d'interface ne doivent pas être codées en dur dans le code métier quand elles relèvent de contenu pédagogique ; stockez-les dans `src/data`.
+
+## 4. Engagement pédagogique et UX
+- Chaque ajout doit renforcer la motivation : feedback positif, progression claire, encouragements empathiques.
+- Évitez les formulations culpabilisantes ; préférez des messages constructifs et inclusifs.
+- Lorsque vous créez des écrans ou animations, validez la compatibilité mobile (consultez `App-mobile-optimized.tsx` et `mobile-optimized.css`).
+
+## 5. Qualité logicielle et tests
+- Avant de soumettre une modification, exécutez :
+  - `npm test` (tests unitaires et composants),
+  - `npm run build` (contrôle de build de production).
+- Ajoutez des tests dans `src/__tests__` pour tout comportement interactif non couvert.
+- Si vous modifiez les scripts, synchronisez `scripts/generate-build-info.js` au besoin et regénérez `public/build-info.json` via `npm run build`.
+
+## 6. Communication dans les PR
+- Les messages de commit et de PR doivent souligner la valeur pédagogique ou UX apportée et résumer les impacts sur le parcours d'apprentissage.
+- Mentionnez explicitement tout changement affectant la langue, le ton, ou l'engagement utilisateur.
+
+Ces directives s'appliquent à l'ensemble du dépôt. Des instructions plus spécifiques peuvent exister dans des `AGENTS.md` plus profonds ; elles prévalent sur ce document dans leur périmètre.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,31 @@
+# Directives techniques pour `src/`
+
+Ces instructions complètent le `AGENTS.md` racine et s'appliquent à tout le code et contenu du dossier `src/`.
+
+## Structure et organisation
+- Réutilisez les dossiers existants : `components` (UI), `data` (contenus pédagogiques), `hooks`, `services`, `utils`, `types`.
+- Toute nouvelle vue doit passer par les hooks fournis (`useRouting`, `useConfirmAction`) pour conserver le routage interne et la logique de confirmation.
+
+## TypeScript & React
+- Typage strict obligatoire : aucune valeur `any`. Utilisez ou étendez les interfaces de `src/types/LearningTypes.ts`.
+- Préférez des composants fonctionnels avec hooks, et factorisez les sous-composants UI dans `components/`.
+- Conservez la compatibilité Material UI : stylisez avec `sx` ou `styled`, pas de CSS inline non contrôlé.
+- Ajoutez un test React Testing Library dans `src/__tests__/` pour toute interaction nouvelle ou modifiée.
+
+## Contenu pédagogique dans le code
+- Les composants ne doivent contenir que de la logique de présentation ou d'orchestration. Les données textuelles (phrases, vocabulaires, consignes) doivent résider dans `src/data`.
+- Lorsque vous affichez du texte luxembourgeois, fournissez au minimum :
+  1. le terme luxembourgeois exact,
+  2. une traduction française claire,
+  3. la prononciation phonétique simple si utile pour l'apprenant.
+- Les messages d'interface doivent encourager l'apprenant et rester positifs.
+
+## Accessibilité et engagement
+- Ajoutez des `aria-*` pertinents pour tous les contrôles non standards. Vérifiez les contrastes avec le thème clair et le thème sombre (`theme.ts` et `theme-dark.ts`).
+- Toute animation doit être testée sur mobile (`App-mobile-optimized.tsx` / `mobile-optimized.css`). Prévoyez une alternative réduite pour les utilisateurs sensibles au mouvement.
+
+## Tests et instrumentation
+- Pour toute nouvelle logique métier, ajoutez des helpers dans `utils/` et couvrez-les par des tests ciblés.
+- Les effets secondaires (localStorage, audio, synthèse vocale) doivent être isolés dans des hooks ou services dédiés et simulés dans les tests.
+
+Respectez également les consignes spécifiques dans les sous-dossiers (ex. `src/data/AGENTS.md`).

--- a/src/data/AGENTS.md
+++ b/src/data/AGENTS.md
@@ -1,0 +1,32 @@
+# Directives pour les contenus pédagogiques (`src/data`)
+
+Ces règles sont prioritaires pour tous les fichiers de données (unités, parcours, contenus de phrases, etc.).
+
+## Structure des fichiers
+- Chaque unité doit exposer explicitement :
+  - un tableau `unitXVocabulary` (`X` = numéro ou identifiant de l'unité),
+  - une fonction `generateUnitXExercises` qui retourne un `Exercise[]`,
+  - une constante `unitX` de type `LearningUnit` si le fichier la définit.
+- Préservez la progression par étapes (commentaires `// ÉTAPE n` existants). Si vous ajoutez une étape, mettez à jour la numérotation et décrivez brièvement l'objectif pédagogique.
+
+## Qualité des données linguistiques
+- `VocabularyItem.luxembourgish` doit toujours contenir la graphie correcte avec diacritiques. Utilisez des identifiants (`id`) en minuscules sans espace ni accent (`moien`, `ech_sinn`...).
+- Complétez systématiquement `french`, `pronunciation` (transcription phonétique simple, majuscules pour syllabes accentuées) et `usage` (contexte d'emploi en français).
+- Lorsque pertinent, ajoutez `audioUrl` ou `imageUrl` pour soutenir différents styles d’apprentissage.
+
+## Conception des exercices
+- Les `Exercise.id` doivent être uniques à l'échelle du dépôt. Préfixez-les avec l'unité (`u01_`, `u15_`) si nécessaire.
+- `correctAnswer` doit correspondre exactement à l'option ou à la phrase attendue. Vérifiez la cohérence entre `options`, `wordBank`, `expectedSentence` et `hint`.
+- Indiquez la valeur `type` en respectant les options de `ExerciseType` (cf. `src/types/LearningTypes.ts`). Toute nouvelle catégorie implique la mise à jour de ce type.
+- Les contextes (`context`) doivent expliquer pourquoi l'exercice est culturellement pertinent ou engageant.
+
+## Cohérence pédagogique et engagement
+- Veillez à alterner compétences (compréhension orale, production, culture) et niveaux de difficulté selon le niveau CECRL annoncé.
+- Introduisez des encouragements ou mini-récompenses textuelles dans les explications (`usage`, `context`) pour soutenir la motivation.
+- Lorsque vous ajoutez une unité, mettez à jour `LearningPathData.ts` ou `unitSections.ts` pour que le parcours reste complet.
+
+## Vérifications
+- Après toute modification de données, exécutez `npm test` pour détecter les régressions, puis faites un `npm run build` pour vérifier l'intégrité du bundle.
+- Lisez le rendu dans l'application (mode desktop et mobile) afin de valider les coupures de lignes et l'affichage des diacritiques.
+
+Ces consignes priment sur les autres fichiers `AGENTS.md` pour toute modification dans `src/data`.


### PR DESCRIPTION
## Summary
- introduce a root AGENTS.md outlining governance, linguistic, development, and engagement rules for Lëtz Learn
- add src/AGENTS.md with coding, accessibility, and testing expectations for the React + TypeScript codebase
- add src/data/AGENTS.md to document linguistic quality, exercise structure, and verification steps for pedagogical content

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: existing SentenceBuilderWorkshop test triggers jsdom media query error)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d50f0a13948328b2173f8fba704200