### PR TITLE
Align beginner sections and add Section 3 progression

### DIFF
--- a/src/data/Unit19Data.ts
+++ b/src/data/Unit19Data.ts
@@ -1,0 +1,167 @@
+// Unit 19: Mobilitéit an Transport - A2 Vie pratique
+// Section 3: Vie pratique (A2)
+
+import { LearningUnit, VocabularyItem, Exercise } from '../types/LearningTypes'
+
+export const unit19Vocabulary: VocabularyItem[] = [
+  {
+    id: 'mobiliteit',
+    luxembourgish: 'Mobilitéit',
+    french: 'mobilité',
+    pronunciation: 'mo-bi-li-TÄIT',
+    usage: 'Capacité à se déplacer au Luxembourg entre communes.'
+  },
+  {
+    id: 'mobilise',
+    luxembourgish: 'Mobilise',
+    french: 'service public Mobilise',
+    pronunciation: 'MO-bi-li-se',
+    usage: 'Nom du service national pour les transports en commun.'
+  },
+  {
+    id: 'mkaart',
+    luxembourgish: 'mKaart',
+    french: 'carte de transport',
+    pronunciation: 'em-KAART',
+    usage: 'Carte à puce pour utiliser trains et bus gratuitement.'
+  },
+  {
+    id: 'zuch',
+    luxembourgish: 'Zuch',
+    french: 'train',
+    pronunciation: 'TSOUKH',
+    usage: 'Train CFL reliant les grandes villes du pays.'
+  },
+  {
+    id: 'busarrêt',
+    luxembourgish: 'Busarrêt',
+    french: 'arrêt de bus',
+    pronunciation: 'BUS-a-rè',
+    usage: 'Point d\'arrêt pour monter dans un bus communal.'
+  },
+  {
+    id: 'veloh',
+    luxembourgish: 'Véloh!',
+    french: 'vélo en libre-service',
+    pronunciation: 'VÉ-lo',
+    usage: 'Système de vélos partagés de la Ville de Luxembourg.'
+  },
+  {
+    id: 'carsharing',
+    luxembourgish: 'Carsharing',
+    french: 'voiture partagée',
+    pronunciation: 'KAAR-sha-ring',
+    usage: 'Service d\'autopartage pour compléter les transports.'
+  },
+  {
+    id: 'statioun',
+    luxembourgish: 'Statioun',
+    french: 'station',
+    pronunciation: 'shta-tsi-OUN',
+    usage: 'Station de tram ou de bus centrale.'
+  },
+  {
+    id: 'tramschinn',
+    luxembourgish: 'Tramschinn',
+    french: 'tramway',
+    pronunciation: 'TRAM-shinn',
+    usage: 'Ligne de tram moderne entre Luxembourg-Ville et Kirchberg.'
+  },
+  {
+    id: 'fahrplang',
+    luxembourgish: 'Fahrplang',
+    french: 'horaire',
+    pronunciation: 'FAR-plang',
+    usage: 'Horaire officiel des transports en commun.'
+  }
+]
+
+export const generateUnit19Exercises = (): Exercise[] => [
+  {
+    id: 'u19_translation_mobiliteit',
+    type: 'translation',
+    vocabularyItem: unit19Vocabulary[0],
+    question: 'Comment dit-on « mobilité » en luxembourgeois ?',
+    options: ['Mobilitéit', 'Fahrplang', 'Tramschinn'],
+    correctAnswer: 'Mobilitéit',
+    context: 'Démarrez par un mot clé pour vous déplacer avec aisance.'
+  },
+  {
+    id: 'u19_dialogue_mobilise',
+    type: 'dialogue_completion',
+    vocabularyItem: unit19Vocabulary[1],
+    question: 'On vous indique le site national pour planifier un trajet. Vous répondez :',
+    options: ['Mobilise', 'Carsharing', 'Véloh!'],
+    correctAnswer: 'Mobilise',
+    context: 'Identifier le service officiel aide à préparer vos trajets.'
+  },
+  {
+    id: 'u19_sentence_mkaart',
+    type: 'sentence_construction',
+    vocabularyItem: unit19Vocabulary[2],
+    question: 'Assemblez une phrase pour dire que vous avez la carte de transport.',
+    wordBank: ['Ech', 'hu', 'meng', 'mKaart'],
+    correctAnswer: 'Ech hu meng mKaart',
+    expectedSentence: 'Ech hu meng mKaart',
+    hint: 'Sujet + verbe avoir + déterminant + carte.',
+    context: 'Exprimer que vous êtes prêt·e à voyager renforce votre autonomie.'
+  },
+  {
+    id: 'u19_audio_zuch',
+    type: 'audio_recognition',
+    vocabularyItem: unit19Vocabulary[3],
+    question: 'Vous entendez l\'annonce d\'un moyen de transport. De quoi s\'agit-il ?',
+    options: ['Zuch', 'Busarrêt', 'Tramschinn'],
+    correctAnswer: 'Zuch',
+    context: 'Reconnaître les annonces sonores rassure pour vos déplacements.'
+  },
+  {
+    id: 'u19_dialogue_bus',
+    type: 'dialogue_completion',
+    vocabularyItem: unit19Vocabulary[4],
+    question: 'Un ami demande où se trouve le prochain arrêt. Vous dites :',
+    options: ['De Busarrêt ass hei.', 'Ech hu meng mKaart.', 'Mobilitéit ass wichteg.'],
+    correctAnswer: 'De Busarrêt ass hei.',
+    context: 'Donner une information concrète fait avancer la conversation.'
+  },
+  {
+    id: 'u19_translation_veloh',
+    type: 'translation',
+    vocabularyItem: unit19Vocabulary[5],
+    question: 'Comment nomme-t-on les vélos partagés à Luxembourg-Ville ?',
+    options: ['Véloh!', 'Carsharing', 'Mobilise'],
+    correctAnswer: 'Véloh!',
+    context: 'Diversifier vos moyens de transport augmente votre liberté.'
+  },
+  {
+    id: 'u19_word_order_fahrplang',
+    type: 'word_ordering',
+    vocabularyItem: unit19Vocabulary[9],
+    question: 'Remettez les mots en ordre pour parler des horaires.',
+    wordBank: ['De', 'Fahrplang', 'ass', 'online'],
+    correctAnswer: 'De Fahrplang ass online',
+    expectedSentence: 'De Fahrplang ass online',
+    hint: 'Commencez par l\'article défini.',
+    context: 'Partager un conseil numérique motive votre partenaire de trajet.'
+  },
+  {
+    id: 'u19_cultural_tram',
+    type: 'cultural_context',
+    vocabularyItem: unit19Vocabulary[8],
+    question: 'Où le tram luxembourgeois est-il particulièrement pratique ?',
+    options: ['Um Kirchberg', 'Am Süden', 'Op der Musel'],
+    correctAnswer: 'Um Kirchberg',
+    context: 'Situer les lignes clés vous rend confiant·e pour rejoindre les institutions.'
+  }
+]
+
+export const learningUnit19: LearningUnit = {
+  id: 'unit_19',
+  title: 'Mobilitéit an Transport',
+  description: 'Déplacez-vous sereinement grâce au réseau gratuit luxembourgeois.',
+  level: 'A2',
+  vocabulary: unit19Vocabulary,
+  exercises: generateUnit19Exercises(),
+  targetScore: 80,
+  estimatedTime: 8
+}

--- a/src/data/Unit20Data.ts
+++ b/src/data/Unit20Data.ts
@@ -1,0 +1,167 @@
+// Unit 20: Administrativ Demarchen - A2 Vie pratique
+// Section 3: Vie pratique (A2)
+
+import { LearningUnit, VocabularyItem, Exercise } from '../types/LearningTypes'
+
+export const unit20Vocabulary: VocabularyItem[] = [
+  {
+    id: 'biergercenter',
+    luxembourgish: 'Bierger-Center',
+    french: 'centre citoyen',
+    pronunciation: 'BIE-jer-sen-ter',
+    usage: 'Guichet principal de Luxembourg-Ville pour démarches rapides.'
+  },
+  {
+    id: 'gemeen',
+    luxembourgish: 'Gemeng',
+    french: 'commune',
+    pronunciation: 'geh-MENG',
+    usage: 'Administration communale qui gère vos dossiers locaux.'
+  },
+  {
+    id: 'meldungskaart',
+    luxembourgish: 'Meldungskaart',
+    french: 'carte de déclaration',
+    pronunciation: 'MEL-dungs-kaart',
+    usage: 'Document pour s\'enregistrer comme résident·e.'
+  },
+  {
+    id: 'residenzbestätegung',
+    luxembourgish: 'Residenzbestätegung',
+    french: 'attestation de résidence',
+    pronunciation: 're-zi-DENTS-besh-TÄ-te-gung',
+    usage: 'Attestation officielle demandée par les banques ou écoles.'
+  },
+  {
+    id: 'formulaire',
+    luxembourgish: 'Formulaire',
+    french: 'formulaire',
+    pronunciation: 'for-mu-LAIR',
+    usage: 'Document à remplir pour votre demande administrative.'
+  },
+  {
+    id: 'dossier',
+    luxembourgish: 'Dossier',
+    french: 'dossier',
+    pronunciation: 'dos-SIÉ',
+    usage: 'Ensemble de documents remis à l\'administration.'
+  },
+  {
+    id: 'termin huelen',
+    luxembourgish: 'Rendez-vous huelen',
+    french: 'prendre rendez-vous',
+    pronunciation: 'ron-day-VOO HOU-len',
+    usage: 'Action de fixer un rendez-vous administratif.'
+  },
+  {
+    id: 'dokumenter',
+    luxembourgish: 'Dokumenter',
+    french: 'documents',
+    pronunciation: 'do-ku-MEN-ter',
+    usage: 'Pièces justificatives nécessaires pour la procédure.'
+  },
+  {
+    id: 'digital',
+    luxembourgish: 'Digital Lëtzebuerg',
+    french: 'administration en ligne',
+    pronunciation: 'DI-gi-tal LET-ze-bourk',
+    usage: 'Portail national pour déposer vos demandes en ligne.'
+  },
+  {
+    id: 'eidas',
+    luxembourgish: 'luxID / eIDAS',
+    french: 'identité électronique',
+    pronunciation: 'luks-ID',
+    usage: 'Carte d\'identité numérique pour signer vos formulaires.'
+  }
+]
+
+export const generateUnit20Exercises = (): Exercise[] => [
+  {
+    id: 'u20_translation_biergercenter',
+    type: 'translation',
+    vocabularyItem: unit20Vocabulary[0],
+    question: 'Comment désigne-t-on le centre citoyen de Luxembourg-Ville ?',
+    options: ['Bierger-Center', 'Gemeng', 'Digital Lëtzebuerg'],
+    correctAnswer: 'Bierger-Center',
+    context: 'Identifier le bon guichet vous fait gagner du temps.'
+  },
+  {
+    id: 'u20_dialogue_gemeng',
+    type: 'dialogue_completion',
+    vocabularyItem: unit20Vocabulary[1],
+    question: 'Un courrier officiel vous invite à contacter la commune. Vous dites :',
+    options: ['Ech ginn op d\'Gemeng.', 'Ech huelen d\'mKaart.', 'Ech fueren mam Zuch.'],
+    correctAnswer: 'Ech ginn op d\'Gemeng.',
+    context: 'Affirmer votre action rassure votre interlocuteur administratif.'
+  },
+  {
+    id: 'u20_word_order_meldung',
+    type: 'word_ordering',
+    vocabularyItem: unit20Vocabulary[2],
+    question: 'Ordonnez la phrase pour dire que vous remplissez votre carte.',
+    wordBank: ['Ech', 'fëllen', 'meng', 'Meldungskaart'],
+    correctAnswer: 'Ech fëllen meng Meldungskaart',
+    expectedSentence: 'Ech fëllen meng Meldungskaart',
+    hint: 'Commencez par le sujet, puis le verbe conjugué.',
+    context: 'Affirmer votre autonomie dans les formulaires est motivant.'
+  },
+  {
+    id: 'u20_cultural_residence',
+    type: 'cultural_context',
+    vocabularyItem: unit20Vocabulary[3],
+    question: 'Quel document rassure une banque sur votre résidence ?',
+    options: ['Residenzbestätegung', 'Meldungskaart', 'Formulaire'],
+    correctAnswer: 'Residenzbestätegung',
+    context: 'Relier les documents aux besoins concrets clarifie vos démarches.'
+  },
+  {
+    id: 'u20_translation_formulaire',
+    type: 'translation',
+    vocabularyItem: unit20Vocabulary[4],
+    question: 'Comment dit-on « formulaire » en luxembourgeois ?',
+    options: ['Formulaire', 'Dokument', 'Dossier'],
+    correctAnswer: 'Formulaire',
+    context: 'Les mots transparents donnent confiance avant de signer.'
+  },
+  {
+    id: 'u20_dialogue_rendezvous',
+    type: 'dialogue_completion',
+    vocabularyItem: unit20Vocabulary[6],
+    question: 'Le guichet vous propose une heure. Vous acceptez en disant :',
+    options: ['Ech huelen de Rendez-vous.', 'Ech fueren mam Tram.', 'Ech liesen de Fahrplang.'],
+    correctAnswer: 'Ech huelen de Rendez-vous.',
+    context: 'Confirmer calmement un rendez-vous montre votre préparation.'
+  },
+  {
+    id: 'u20_sentence_documents',
+    type: 'sentence_construction',
+    vocabularyItem: unit20Vocabulary[7],
+    question: 'Formez une phrase pour dire que vous avez tous les documents.',
+    wordBank: ['Ech', 'hu', 'all', 'meng', 'Dokumenter'],
+    correctAnswer: 'Ech hu all meng Dokumenter',
+    expectedSentence: 'Ech hu all meng Dokumenter',
+    hint: 'Placez le verbe en deuxième position.',
+    context: 'Se féliciter renforce la motivation avant le rendez-vous.'
+  },
+  {
+    id: 'u20_cultural_digital',
+    type: 'cultural_context',
+    vocabularyItem: unit20Vocabulary[8],
+    question: 'Quel portail vous permet de déposer une demande en ligne ?',
+    options: ['Digital Lëtzebuerg', 'Bierger-Center', 'Gemeng'],
+    correctAnswer: 'Digital Lëtzebuerg',
+    context: 'Utiliser le numérique simplifie vos démarches où que vous soyez.'
+  }
+]
+
+export const learningUnit20: LearningUnit = {
+  id: 'unit_20',
+  title: 'Administrativ Demarchen',
+  description: 'Préparez vos documents et dialogues pour les démarches courantes.',
+  level: 'A2',
+  vocabulary: unit20Vocabulary,
+  exercises: generateUnit20Exercises(),
+  targetScore: 80,
+  estimatedTime: 8
+}

--- a/src/data/Unit21Data.ts
+++ b/src/data/Unit21Data.ts
@@ -1,0 +1,167 @@
+// Unit 21: Suen a Budget - A2 Vie pratique
+// Section 3: Vie pratique (A2)
+
+import { LearningUnit, VocabularyItem, Exercise } from '../types/LearningTypes'
+
+export const unit21Vocabulary: VocabularyItem[] = [
+  {
+    id: 'budget',
+    luxembourgish: 'Budget',
+    french: 'budget',
+    pronunciation: 'BU-djett',
+    usage: 'Plan de dépenses pour votre quotidien au Luxembourg.'
+  },
+  {
+    id: 'kont',
+    luxembourgish: 'Kont',
+    french: 'compte bancaire',
+    pronunciation: 'KONT',
+    usage: 'Compte bancaire luxembourgeois pour recevoir votre salaire.'
+  },
+  {
+    id: 'spuerkont',
+    luxembourgish: 'Spuerkont',
+    french: 'compte épargne',
+    pronunciation: 'SHPOUR-kont',
+    usage: 'Compte pour économiser et préparer vos projets.'
+  },
+  {
+    id: 'staatleche_prime',
+    luxembourgish: 'Staatlech Prime',
+    french: 'prime étatique',
+    pronunciation: 'SHTAAT-lekh PRI-me',
+    usage: 'Aide financière du gouvernement (p.ex. loyer, mobilité).'
+  },
+  {
+    id: 'steier',
+    luxembourgish: 'Steier',
+    french: 'impôt',
+    pronunciation: 'SHTAY-er',
+    usage: 'Impôt sur le revenu ou les achats (TVA).'
+  },
+  {
+    id: 'recu',
+    luxembourgish: 'Reçu',
+    french: 'reçu',
+    pronunciation: 're-SÜ',
+    usage: 'Preuve de paiement à conserver pour vos dossiers.'
+  },
+  {
+    id: 'ausgab',
+    luxembourgish: 'Ausgab',
+    french: 'dépense',
+    pronunciation: 'AOS-gab',
+    usage: 'Argent que vous sortez pour vos achats quotidiens.'
+  },
+  {
+    id: 'spueren',
+    luxembourgish: 'Spueren',
+    french: 'économiser',
+    pronunciation: 'SHPOU-ren',
+    usage: 'Mettre de côté pour un projet ou une sécurité.'
+  },
+  {
+    id: 'bancomat',
+    luxembourgish: 'Bancomat',
+    french: 'distributeur automatique',
+    pronunciation: 'BAN-ko-mat',
+    usage: 'Guichet automatique pour retirer des espèces.'
+  },
+  {
+    id: 'familienzulag',
+    luxembourgish: 'Familljenzoulage',
+    french: 'allocation familiale',
+    pronunciation: 'fa-MILL-yen-tsou-lach',
+    usage: 'Soutien financier versé aux familles résidentes.'
+  }
+]
+
+export const generateUnit21Exercises = (): Exercise[] => [
+  {
+    id: 'u21_translation_budget',
+    type: 'translation',
+    vocabularyItem: unit21Vocabulary[0],
+    question: 'Comment dit-on « budget » en luxembourgeois ?',
+    options: ['Budget', 'Steier', 'Ausgab'],
+    correctAnswer: 'Budget',
+    context: 'Nommer votre budget vous aide à mieux le suivre.'
+  },
+  {
+    id: 'u21_dialogue_kont',
+    type: 'dialogue_completion',
+    vocabularyItem: unit21Vocabulary[1],
+    question: 'Votre banque vous confirme l\'ouverture. Vous répondez :',
+    options: ['Ech hunn en neie Kont.', 'Ech fëllen d\'Meldungskaart.', 'Ech fueren mam Tram.'],
+    correctAnswer: 'Ech hunn en neie Kont.',
+    context: 'Exprimer votre réussite valorise vos efforts administratifs.'
+  },
+  {
+    id: 'u21_sentence_spuerkont',
+    type: 'sentence_construction',
+    vocabularyItem: unit21Vocabulary[2],
+    question: 'Formez une phrase pour dire que vous ouvrez un compte épargne.',
+    wordBank: ['Ech', 'maachen', 'en', 'Spuerkont', 'op'],
+    correctAnswer: 'Ech maachen en Spuerkont op',
+    expectedSentence: 'Ech maachen en Spuerkont op',
+    hint: 'Le verbe à particule séparable se place à la fin.',
+    context: 'Souligner un projet personnel motive votre progression.'
+  },
+  {
+    id: 'u21_cultural_prime',
+    type: 'cultural_context',
+    vocabularyItem: unit21Vocabulary[3],
+    question: 'Quelle aide mentionnez-vous pour la mobilité durable ?',
+    options: ['Staatlech Prime', 'Reçu', 'Spuerkont'],
+    correctAnswer: 'Staatlech Prime',
+    context: 'Connaître les primes nationales encourage les démarches écologiques.'
+  },
+  {
+    id: 'u21_translation_steier',
+    type: 'translation',
+    vocabularyItem: unit21Vocabulary[4],
+    question: 'Comment dit-on « impôt » en luxembourgeois ?',
+    options: ['Steier', 'Ausgab', 'Budget'],
+    correctAnswer: 'Steier',
+    context: 'Identifier le vocabulaire fiscal clarifie vos obligations.'
+  },
+  {
+    id: 'u21_dialogue_recu',
+    type: 'dialogue_completion',
+    vocabularyItem: unit21Vocabulary[5],
+    question: 'Après un achat, vous demandez une preuve. Vous dites :',
+    options: ['Kritt ech w.e.g. e Reçu?', 'Ech huelen de Rendez-vous.', 'Ech fueren op d\'Gemeng.'],
+    correctAnswer: 'Kritt ech w.e.g. e Reçu?',
+    context: 'Demander poliment vous aide à suivre votre budget.'
+  },
+  {
+    id: 'u21_word_order_ausgab',
+    type: 'word_ordering',
+    vocabularyItem: unit21Vocabulary[6],
+    question: 'Remettez les mots en ordre pour parler d\'une dépense.',
+    wordBank: ['Dës', 'Ausgab', 'ass', 'fir', 'den', 'Iessenbudget'],
+    correctAnswer: 'Dës Ausgab ass fir den Iessenbudget',
+    expectedSentence: 'Dës Ausgab ass fir den Iessenbudget',
+    hint: 'Commencez par l\'adjectif démonstratif.',
+    context: 'Classer vos dépenses rend votre plan plus motivant.'
+  },
+  {
+    id: 'u21_cultural_familljen',
+    type: 'cultural_context',
+    vocabularyItem: unit21Vocabulary[9],
+    question: 'Quelle aide financière soutient les familles au Luxembourg ?',
+    options: ['Familljenzoulage', 'Steier', 'Bancomat'],
+    correctAnswer: 'Familljenzoulage',
+    context: 'Connaître les droits familiaux renforce votre sentiment de sécurité.'
+  }
+]
+
+export const learningUnit21: LearningUnit = {
+  id: 'unit_21',
+  title: 'Suen a Budget',
+  description: 'Organisez vos dépenses et dialoguez avec votre banque.',
+  level: 'A2',
+  vocabulary: unit21Vocabulary,
+  exercises: generateUnit21Exercises(),
+  targetScore: 80,
+  estimatedTime: 8
+}

--- a/src/data/Unit22Data.ts
+++ b/src/data/Unit22Data.ts
@@ -1,0 +1,167 @@
+// Unit 22: Aarbecht a Formatioun - A2 Vie pratique
+// Section 3: Vie pratique (A2)
+
+import { LearningUnit, VocabularyItem, Exercise } from '../types/LearningTypes'
+
+export const unit22Vocabulary: VocabularyItem[] = [
+  {
+    id: 'arbechtskontrakt',
+    luxembourgish: 'Aarbechtskontrakt',
+    french: 'contrat de travail',
+    pronunciation: 'AAR-bekhts-kon-trakt',
+    usage: 'Document qui définit vos conditions de travail.'
+  },
+  {
+    id: 'stage',
+    luxembourgish: 'Stage',
+    french: 'stage',
+    pronunciation: 'SHTASH',
+    usage: 'Période d\'apprentissage pratique en entreprise.'
+  },
+  {
+    id: 'gehalt',
+    luxembourgish: 'Gehalt',
+    french: 'salaire',
+    pronunciation: 'geh-HALT',
+    usage: 'Rémunération mensuelle versée par l\'employeur.'
+  },
+  {
+    id: 'arbechtsamt',
+    luxembourgish: 'ADEM',
+    french: 'agence pour l\'emploi',
+    pronunciation: 'A-DEMM',
+    usage: 'Agence luxembourgeoise de placement et de formation.'
+  },
+  {
+    id: 'weiderbildung',
+    luxembourgish: 'Weiderbildung',
+    french: 'formation continue',
+    pronunciation: 'VAI-der-bil-dung',
+    usage: 'Formation pour développer vos compétences.'
+  },
+  {
+    id: 'motivationnsbréif',
+    luxembourgish: 'Motivatiounsbréif',
+    french: 'lettre de motivation',
+    pronunciation: 'mo-ti-VA-tsions-brêf',
+    usage: 'Lettre envoyée pour exprimer votre motivation à un employeur.'
+  },
+  {
+    id: 'gesprech',
+    luxembourgish: 'Gespréich',
+    french: 'entretien',
+    pronunciation: 'ge-SHPRÄÏSH',
+    usage: 'Entretien de recrutement ou d\'évaluation.'
+  },
+  {
+    id: 'arbechtszäiten',
+    luxembourgish: 'Aarbechtszäiten',
+    french: 'horaires de travail',
+    pronunciation: 'AAR-bekhts-TSÄÏ-ten',
+    usage: 'Heures convenues dans votre contrat.'
+  },
+  {
+    id: 'team',
+    luxembourgish: 'Equipe / Team',
+    french: 'équipe',
+    pronunciation: 'EE-keep',
+    usage: 'Groupe de collègues avec qui vous collaborez.'
+  },
+  {
+    id: 'arbechtsrecht',
+    luxembourgish: 'Aarbechtsrecht',
+    french: 'droit du travail',
+    pronunciation: 'AAR-bekhts-rekht',
+    usage: 'Règles qui protègent salariés et employeurs.'
+  }
+]
+
+export const generateUnit22Exercises = (): Exercise[] => [
+  {
+    id: 'u22_translation_kontrakt',
+    type: 'translation',
+    vocabularyItem: unit22Vocabulary[0],
+    question: 'Comment dit-on « contrat de travail » en luxembourgeois ?',
+    options: ['Aarbechtskontrakt', 'Motivatiounsbréif', 'Stage'],
+    correctAnswer: 'Aarbechtskontrakt',
+    context: 'Connaître vos documents clés vous rend confiant·e.'
+  },
+  {
+    id: 'u22_dialogue_adem',
+    type: 'dialogue_completion',
+    vocabularyItem: unit22Vocabulary[3],
+    question: 'Où prenez-vous rendez-vous pour un accompagnement emploi ?',
+    options: ['Bei der ADEM', 'Um Tram', 'An der Gemeng'],
+    correctAnswer: 'Bei der ADEM',
+    context: 'Savoir à qui s\'adresser ouvre des opportunités positives.'
+  },
+  {
+    id: 'u22_sentence_stage',
+    type: 'sentence_construction',
+    vocabularyItem: unit22Vocabulary[1],
+    question: 'Composez une phrase pour annoncer que vous commencez un stage.',
+    wordBank: ['Ech', 'fänken', 'e', 'Stage', 'un'],
+    correctAnswer: 'Ech fänken e Stage un',
+    expectedSentence: 'Ech fänken e Stage un',
+    hint: 'Le verbe « ufänken » place la particule « un » à la fin.',
+    context: 'Célébrer un nouveau départ soutient votre motivation.'
+  },
+  {
+    id: 'u22_cultural_weiderbildung',
+    type: 'cultural_context',
+    vocabularyItem: unit22Vocabulary[4],
+    question: 'Comment parle-t-on des formations financées pour adultes ?',
+    options: ['Weiderbildung', 'Gehalt', 'Equipe'],
+    correctAnswer: 'Weiderbildung',
+    context: 'Identifier les ressources renforce votre confiance professionnelle.'
+  },
+  {
+    id: 'u22_translation_motivatioun',
+    type: 'translation',
+    vocabularyItem: unit22Vocabulary[5],
+    question: 'Comment dit-on « lettre de motivation » en luxembourgeois ?',
+    options: ['Motivatiounsbréif', 'Aarbechtsrecht', 'Aarbechtszäiten'],
+    correctAnswer: 'Motivatiounsbréif',
+    context: 'Nommer votre document valorise votre candidature.'
+  },
+  {
+    id: 'u22_dialogue_gesprech',
+    type: 'dialogue_completion',
+    vocabularyItem: unit22Vocabulary[6],
+    question: 'Vous confirmez votre présence à un entretien. Vous dites :',
+    options: ['Ech sinn beim Gespréich dobäi.', 'Ech fueren op d\'Gemeng.', 'Ech liesen de Fahrplang.'],
+    correctAnswer: 'Ech sinn beim Gespréich dobäi.',
+    context: 'Se montrer disponible crée une ambiance collaborative.'
+  },
+  {
+    id: 'u22_word_order_arbechtszaiten',
+    type: 'word_ordering',
+    vocabularyItem: unit22Vocabulary[7],
+    question: 'Remettez les mots en ordre pour évoquer les horaires.',
+    wordBank: ['Meng', 'Aarbechtszäiten', 'si', 'flexibel'],
+    correctAnswer: 'Meng Aarbechtszäiten si flexibel',
+    expectedSentence: 'Meng Aarbechtszäiten si flexibel',
+    hint: 'Le verbe « sinn » reste en deuxième position.',
+    context: 'Parler de flexibilité instaure un climat positif au travail.'
+  },
+  {
+    id: 'u22_cultural_team',
+    type: 'cultural_context',
+    vocabularyItem: unit22Vocabulary[8],
+    question: 'Quel mot mixte français-anglais décrit souvent votre équipe ?',
+    options: ['Equipe / Team', 'Stage', 'Aarbechtsrecht'],
+    correctAnswer: 'Equipe / Team',
+    context: 'Valoriser votre équipe renforce le sentiment d\'appartenance.'
+  }
+]
+
+export const learningUnit22: LearningUnit = {
+  id: 'unit_22',
+  title: 'Aarbecht a Formatioun',
+  description: 'Préparez vos démarches emploi et vos dialogues professionnels.',
+  level: 'A2',
+  vocabulary: unit22Vocabulary,
+  exercises: generateUnit22Exercises(),
+  targetScore: 80,
+  estimatedTime: 8
+}

--- a/src/data/Unit23Data.ts
+++ b/src/data/Unit23Data.ts
@@ -1,0 +1,167 @@
+// Unit 23: Famill a Schoul - A2 Vie pratique
+// Section 3: Vie pratique (A2)
+
+import { LearningUnit, VocabularyItem, Exercise } from '../types/LearningTypes'
+
+export const unit23Vocabulary: VocabularyItem[] = [
+  {
+    id: 'kräibierg',
+    luxembourgish: 'Krëpp',
+    french: 'crèche',
+    pronunciation: 'KREPP',
+    usage: 'Structure d\'accueil pour les enfants de 0 à 3 ans.'
+  },
+  {
+    id: 'maison_relais',
+    luxembourgish: 'Maison Relais',
+    french: 'service d\'accueil périscolaire',
+    pronunciation: 'mé-zon re-LÄ',
+    usage: 'Accueil après l\'école dans la plupart des communes.'
+  },
+  {
+    id: 'schoul',
+    luxembourgish: 'Schoul',
+    french: 'école',
+    pronunciation: 'SHOUL',
+    usage: 'Établissement scolaire pour enfants et adolescents.'
+  },
+  {
+    id: 'cycle',
+    luxembourgish: 'Cycle',
+    french: 'cycle scolaire',
+    pronunciation: 'SI-kel',
+    usage: 'Période d\'apprentissage dans l\'enseignement fondamental.'
+  },
+  {
+    id: 'bichelchen',
+    luxembourgish: 'Bichelchen',
+    french: 'cahier',
+    pronunciation: 'BI-shel-khen',
+    usage: 'Petit cahier pour les devoirs et messages enseignants.'
+  },
+  {
+    id: 'schoulmaterial',
+    luxembourgish: 'Schoulmaterial',
+    french: 'fournitures scolaires',
+    pronunciation: 'SHOUL-ma-te-ri-AL',
+    usage: 'Matériel scolaire demandé en début d\'année.'
+  },
+  {
+    id: 'elterendeel',
+    luxembourgish: 'Elterendeel',
+    french: 'parent',
+    pronunciation: 'EL-teren-deel',
+    usage: 'Parent ou tuteur impliqué dans la scolarité.'
+  },
+  {
+    id: 'reunioun',
+    luxembourgish: 'Eltereversammelung',
+    french: 'réunion parents-professeurs',
+    pronunciation: 'EL-tere-fer-SAM-me-lung',
+    usage: 'Réunion pour échanger avec l\'enseignant·e.'
+  },
+  {
+    id: 'canteen',
+    luxembourgish: 'Schoulkantin',
+    french: 'cantine scolaire',
+    pronunciation: 'SHOUL-kan-tinn',
+    usage: 'Repas chaud proposé aux enfants à midi.'
+  },
+  {
+    id: 'schoultransport',
+    luxembourgish: 'Schoultransport',
+    french: 'transport scolaire',
+    pronunciation: 'SHOUL-trans-port',
+    usage: 'Bus organisés par la commune pour les élèves.'
+  }
+]
+
+export const generateUnit23Exercises = (): Exercise[] => [
+  {
+    id: 'u23_translation_krepp',
+    type: 'translation',
+    vocabularyItem: unit23Vocabulary[0],
+    question: 'Comment dit-on « crèche » en luxembourgeois ?',
+    options: ['Krëpp', 'Schoul', 'Schoultransport'],
+    correctAnswer: 'Krëpp',
+    context: 'Nommer la structure d\'accueil facilite vos inscriptions.'
+  },
+  {
+    id: 'u23_dialogue_maison_relais',
+    type: 'dialogue_completion',
+    vocabularyItem: unit23Vocabulary[1],
+    question: 'Vous remerciez le service périscolaire. Vous dites :',
+    options: ['D\'Maison Relais ass immens hëllefräich.', 'Ech fänken e Stage un.', 'Ech huelen de Rendez-vous.'],
+    correctAnswer: 'D\'Maison Relais ass immens hëllefräich.',
+    context: 'Exprimer de la gratitude crée un lien chaleureux.'
+  },
+  {
+    id: 'u23_sentence_bichelchen',
+    type: 'sentence_construction',
+    vocabularyItem: unit23Vocabulary[4],
+    question: 'Formez une phrase pour dire que le cahier est signé.',
+    wordBank: ['D\'', 'Bichelchen', 'ass', 'ënnerschriwwen'],
+    correctAnswer: 'D\' Bichelchen ass ënnerschriwwen',
+    expectedSentence: 'D\' Bichelchen ass ënnerschriwwen',
+    hint: 'L\'article se contracte avec le mot suivant.',
+    context: 'Suivre les communications renforce la confiance avec l\'école.'
+  },
+  {
+    id: 'u23_cultural_cycle',
+    type: 'cultural_context',
+    vocabularyItem: unit23Vocabulary[3],
+    question: 'Comment s\'appellent les étapes de l\'enseignement fondamental ?',
+    options: ['Cycle', 'Krëpp', 'Elterendeel'],
+    correctAnswer: 'Cycle',
+    context: 'Comprendre l\'organisation scolaire rassure toute la famille.'
+  },
+  {
+    id: 'u23_translation_schoulmaterial',
+    type: 'translation',
+    vocabularyItem: unit23Vocabulary[5],
+    question: 'Comment parle-t-on des fournitures scolaires ?',
+    options: ['Schoulmaterial', 'Schoulkantin', 'Schoultransport'],
+    correctAnswer: 'Schoulmaterial',
+    context: 'Préparer le matériel montre votre engagement parental.'
+  },
+  {
+    id: 'u23_dialogue_reunion',
+    type: 'dialogue_completion',
+    vocabularyItem: unit23Vocabulary[7],
+    question: 'Vous confirmez votre présence à la réunion. Vous dites :',
+    options: ['Ech kommen op d\'Eltereversammelung.', 'Ech spueren am Spuerkont.', 'Ech ginn op d\'Gemeng.'],
+    correctAnswer: 'Ech kommen op d\'Eltereversammelung.',
+    context: 'Être présent·e renforce la collaboration avec l\'enseignant·e.'
+  },
+  {
+    id: 'u23_word_order_canteen',
+    type: 'word_ordering',
+    vocabularyItem: unit23Vocabulary[8],
+    question: 'Remettez les mots en ordre pour parler de la cantine.',
+    wordBank: ['D', 'Schoulkantin', 'bitt', 'gesond', 'Iessen'],
+    correctAnswer: 'D Schoulkantin bitt gesond Iessen',
+    expectedSentence: 'D Schoulkantin bitt gesond Iessen',
+    hint: 'Commencez par l\'article abrégé « D » pour le féminin.',
+    context: 'Soulever la qualité des repas encourage de bonnes habitudes.'
+  },
+  {
+    id: 'u23_cultural_transport',
+    type: 'cultural_context',
+    vocabularyItem: unit23Vocabulary[9],
+    question: 'Quel service garantit un trajet sûr vers l\'école ?',
+    options: ['Schoultransport', 'Krëpp', 'Bichelchen'],
+    correctAnswer: 'Schoultransport',
+    context: 'Connaitre les aides locales rassure sur l\'organisation familiale.'
+  }
+]
+
+export const learningUnit23: LearningUnit = {
+  id: 'unit_23',
+  title: 'Famill a Schoul',
+  description: 'Accompagnez vos enfants et échangez avec l\'école en confiance.',
+  level: 'A2',
+  vocabulary: unit23Vocabulary,
+  exercises: generateUnit23Exercises(),
+  targetScore: 80,
+  estimatedTime: 8
+}

--- a/src/data/Unit24Data.ts
+++ b/src/data/Unit24Data.ts
@@ -1,0 +1,167 @@
+// Unit 24: Integratioun a Gemeinschaft - A2 Vie pratique
+// Section 3: Vie pratique (A2)
+
+import { LearningUnit, VocabularyItem, Exercise } from '../types/LearningTypes'
+
+export const unit24Vocabulary: VocabularyItem[] = [
+  {
+    id: 'integratioun',
+    luxembourgish: 'Integratioun',
+    french: 'intégration',
+    pronunciation: 'in-te-gra-TSI-oun',
+    usage: 'Processus pour participer activement à la société luxembourgeoise.'
+  },
+  {
+    id: 'cours_lux',
+    luxembourgish: 'Cours de Lëtzebuergesch',
+    french: 'cours de luxembourgeois',
+    pronunciation: 'KOUR de LET-ze-bour-gesch',
+    usage: 'Cours organisés par communes et associations pour apprendre la langue.'
+  },
+  {
+    id: 'sproochentest',
+    luxembourgish: 'Sproochentest',
+    french: 'test de langue',
+    pronunciation: 'SHPROH-khen-test',
+    usage: 'Examen officiel demandé pour la nationalité.'
+  },
+  {
+    id: 'volontariat',
+    luxembourgish: 'Fräiwëllegeprojet',
+    french: 'projet de volontariat',
+    pronunciation: 'FRAÏ-vël-le-ge-pro-jet',
+    usage: 'Projet bénévole pour rencontrer des habitants.'
+  },
+  {
+    id: 'fest',
+    luxembourgish: 'Fest',
+    french: 'fête locale',
+    pronunciation: 'FEST',
+    usage: 'Événement communal ou national rassemblant les habitants.'
+  },
+  {
+    id: 'geschichtsatelier',
+    luxembourgish: 'Geschichtsatelier',
+    french: 'atelier d\'histoire locale',
+    pronunciation: 'ge-SHIKHTS-atelier',
+    usage: 'Atelier qui raconte l\'histoire et les traditions du pays.'
+  },
+  {
+    id: 'asso',
+    luxembourgish: 'Veräin',
+    french: 'association',
+    pronunciation: 've-RAÏN',
+    usage: 'Association sportive ou culturelle pour créer des liens.'
+  },
+  {
+    id: 'buergerpakt',
+    luxembourgish: 'Biergerpakt',
+    french: 'pacte citoyen',
+    pronunciation: 'BIER-ger-pakt',
+    usage: 'Programme d\'accueil communal pour nouveaux habitants.'
+  },
+  {
+    id: 'gemeindfest',
+    luxembourgish: 'Gemengefest',
+    french: 'fête communale',
+    pronunciation: 'ge-MENG-ge-fest',
+    usage: 'Fête organisée par la commune avec animations.'
+  },
+  {
+    id: 'nationalitet',
+    luxembourgish: 'Nationalitéit',
+    french: 'nationalité',
+    pronunciation: 'na-tsio-na-li-TÄIT',
+    usage: 'Statut juridique qui reconnaît votre appartenance au pays.'
+  }
+]
+
+export const generateUnit24Exercises = (): Exercise[] => [
+  {
+    id: 'u24_translation_integratioun',
+    type: 'translation',
+    vocabularyItem: unit24Vocabulary[0],
+    question: 'Comment dit-on « intégration » en luxembourgeois ?',
+    options: ['Integratioun', 'Veräin', 'Fest'],
+    correctAnswer: 'Integratioun',
+    context: 'Nommer votre objectif donne du sens à chaque rencontre.'
+  },
+  {
+    id: 'u24_dialogue_cours',
+    type: 'dialogue_completion',
+    vocabularyItem: unit24Vocabulary[1],
+    question: 'Vous invitez un ami à apprendre la langue. Vous dites :',
+    options: ['Kommt mat an de Cours de Lëtzebuergesch!', 'Ech ginn op d\'Gemeng.', 'Ech spueren am Spuerkont.'],
+    correctAnswer: 'Kommt mat an de Cours de Lëtzebuergesch!',
+    context: 'Partager un cours crée un soutien mutuel inspirant.'
+  },
+  {
+    id: 'u24_sentence_sproochentest',
+    type: 'sentence_construction',
+    vocabularyItem: unit24Vocabulary[2],
+    question: 'Formez une phrase pour dire que vous préparez le test de langue.',
+    wordBank: ['Ech', 'bereeden', 'de', 'Sproochentest', 'vir'],
+    correctAnswer: 'Ech bereeden de Sproochentest vir',
+    expectedSentence: 'Ech bereeden de Sproochentest vir',
+    hint: 'Le verbe à particule « virbereeden » envoie « vir » à la fin.',
+    context: 'Mettre en mots votre préparation renforce votre confiance.'
+  },
+  {
+    id: 'u24_cultural_volontariat',
+    type: 'cultural_context',
+    vocabularyItem: unit24Vocabulary[3],
+    question: 'Quelle activité vous rapproche d\'habitants engagés ?',
+    options: ['Fräiwëllegeprojet', 'Gemengefest', 'Sproochentest'],
+    correctAnswer: 'Fräiwëllegeprojet',
+    context: 'Le bénévolat ouvre des échanges chaleureux.'
+  },
+  {
+    id: 'u24_translation_verain',
+    type: 'translation',
+    vocabularyItem: unit24Vocabulary[6],
+    question: 'Comment parle-t-on d\'une association en luxembourgeois ?',
+    options: ['Veräin', 'Biergerpakt', 'Fest'],
+    correctAnswer: 'Veräin',
+    context: 'Identifier les associations vous aide à participer activement.'
+  },
+  {
+    id: 'u24_dialogue_buergerpakt',
+    type: 'dialogue_completion',
+    vocabularyItem: unit24Vocabulary[7],
+    question: 'La commune vous propose un programme d\'accueil. Vous répondez :',
+    options: ['Ech maachen beim Biergerpakt mat.', 'Ech liesen de Fahrplang.', 'Ech froe fir eng Residenzbestätegung.'],
+    correctAnswer: 'Ech maachen beim Biergerpakt mat.',
+    context: 'Accepter le pacte citoyen favorise votre intégration positive.'
+  },
+  {
+    id: 'u24_word_order_fest',
+    type: 'word_ordering',
+    vocabularyItem: unit24Vocabulary[4],
+    question: 'Remettez les mots en ordre pour annoncer une fête locale.',
+    wordBank: ['D', 'Gemeng', 'organiséiert', 'e', 'Fest'],
+    correctAnswer: 'D Gemeng organiséiert e Fest',
+    expectedSentence: 'D Gemeng organiséiert e Fest',
+    hint: 'Commencez par l\'article abrégé « D ».',
+    context: 'Inviter vos amis aux fêtes renforce votre cercle social.'
+  },
+  {
+    id: 'u24_cultural_nationalitet',
+    type: 'cultural_context',
+    vocabularyItem: unit24Vocabulary[9],
+    question: 'Quel mot nomme l\'objectif final de naturalisation ?',
+    options: ['Nationalitéit', 'Integratioun', 'Cours de Lëtzebuergesch'],
+    correctAnswer: 'Nationalitéit',
+    context: 'Visualiser votre but final maintient votre motivation sur la durée.'
+  }
+]
+
+export const learningUnit24: LearningUnit = {
+  id: 'unit_24',
+  title: 'Integratioun a Gemeinschaft',
+  description: 'Participez aux événements locaux et préparez vos démarches citoyennes.',
+  level: 'A2',
+  vocabulary: unit24Vocabulary,
+  exercises: generateUnit24Exercises(),
+  targetScore: 80,
+  estimatedTime: 8
+}

--- a/src/data/unitSections.ts
+++ b/src/data/unitSections.ts
@@ -23,6 +23,12 @@ import { learningUnit16 } from './Unit16Data'
 // Import practical life units (Section 3)
 import { learningUnit17 } from './Unit17Data'
 import { learningUnit18 } from './Unit18Data'
+import { learningUnit19 } from './Unit19Data'
+import { learningUnit20 } from './Unit20Data'
+import { learningUnit21 } from './Unit21Data'
+import { learningUnit22 } from './Unit22Data'
+import { learningUnit23 } from './Unit23Data'
+import { learningUnit24 } from './Unit24Data'
 
 export const beginnerUnitSections: UnitSection[] = [
   {
@@ -82,7 +88,13 @@ export const beginnerUnitSections: UnitSection[] = [
     order: 3,
     units: [
       learningUnit17,
-      learningUnit18
+      learningUnit18,
+      learningUnit19,
+      learningUnit20,
+      learningUnit21,
+      learningUnit22,
+      learningUnit23,
+      learningUnit24
     ],
     pathLayout: [
       { x: 25, y: 20 },

--- a/src/data/unitSections.ts
+++ b/src/data/unitSections.ts
@@ -6,7 +6,7 @@ import { learningUnit2 } from './Unit2NewData'
 import { learningUnit3 } from './Unit3NewData'
 import { learningUnit4 } from './Unit4NewData'
 import { learningUnit5 } from './Unit5NewData'
-import { learningUnit6 } from './Unit6Data'  // Use original version
+import { learningUnit6 } from './Unit6Data' // Use original version
 import { learningUnit7New } from './Unit7NewData'
 import { learningUnit8New } from './Unit8NewData'
 
@@ -20,11 +20,16 @@ import { learningUnit14 } from './Unit14Data'
 import { learningUnit15 } from './Unit15Data'
 import { learningUnit16 } from './Unit16Data'
 
+// Import practical life units (Section 3)
+import { learningUnit17 } from './Unit17Data'
+import { learningUnit18 } from './Unit18Data'
+
 export const beginnerUnitSections: UnitSection[] = [
   {
     id: 'section_1',
-    title: 'Section 1 - Fondamentaux (Unités 1-8)',
-    description: 'Découvrez les bases du luxembourgeois',
+    title: 'Section 1 - Premiers pas au quotidien (Unités 1-8)',
+    description:
+      'Découvrez les salutations, les chiffres et les automatismes essentiels pour créer le contact en luxembourgeois.',
     color: '#4ade80',
     order: 1,
     units: [
@@ -47,7 +52,8 @@ export const beginnerUnitSections: UnitSection[] = [
   {
     id: 'section_2',
     title: 'Section 2 - Communication quotidienne (Unités 9-16)',
-    description: 'Maîtrisez les conversations et situations du quotidien au Luxembourg',
+    description:
+      'Affinez vos interactions : poser des questions, organiser vos déplacements et gérer les services du quotidien avec aisance.',
     color: '#3b82f6',
     order: 2,
     units: [
@@ -65,6 +71,28 @@ export const beginnerUnitSections: UnitSection[] = [
       { x: 25, y: 40 }, { x: 75, y: 40 }, // Units 11-12
       { x: 25, y: 60 }, { x: 75, y: 60 }, // Units 13-14
       { x: 25, y: 80 }, { x: 75, y: 80 }  // Units 15-16
+    ]
+  },
+  {
+    id: 'section_3',
+    title: 'Section 3 - Vie pratique et autonomie (Unités 17-24)',
+    description:
+      'Préparez-vous à vivre au Luxembourg : logement, santé et démarches concrètes pour gagner en autonomie (niveau A2).',
+    color: '#f97316',
+    order: 3,
+    units: [
+      learningUnit17,
+      learningUnit18
+    ],
+    pathLayout: [
+      { x: 25, y: 20 },
+      { x: 75, y: 20 },
+      { x: 25, y: 40 },
+      { x: 75, y: 40 },
+      { x: 25, y: 60 },
+      { x: 75, y: 60 },
+      { x: 25, y: 80 },
+      { x: 75, y: 80 }
     ]
   }
 ]

--- a/src/styles/SimpleUnitsList.css
+++ b/src/styles/SimpleUnitsList.css
@@ -161,6 +161,22 @@
   box-shadow: 0 8px 25px rgba(59, 130, 246, 0.2);
 }
 
+/* Practical life styling for Section 3 units */
+.unit-card.advanced {
+  border-left: 4px solid #f97316;
+}
+
+.unit-card.advanced .unit-icon {
+  background: linear-gradient(135deg, #f97316 0%, #c2410c 100%);
+  color: white;
+  box-shadow: 0 4px 12px rgba(249, 115, 22, 0.3);
+}
+
+.unit-card.advanced:hover {
+  border-color: #c2410c;
+  box-shadow: 0 8px 25px rgba(249, 115, 22, 0.2);
+}
+
 /* Locked unit styling with motivation hints */
 .unit-card.locked {
   opacity: 0.6;
@@ -378,6 +394,15 @@
   background: rgba(59, 130, 246, 0.2);
 }
 
+.section-card.section-3 {
+  background: rgba(249, 115, 22, 0.15);
+  border-color: rgba(249, 115, 22, 0.3);
+}
+
+.section-card.section-3 .section-progress {
+  background: rgba(249, 115, 22, 0.2);
+}
+
 /* Section completion celebration */
 .section-completed-celebration {
   position: relative;
@@ -411,6 +436,19 @@
 .intermediate-level {
   background: linear-gradient(135deg, #3b82f6 0%, #1e40af 100%);
   color: white !important;
+}
+
+.advanced-level {
+  background: linear-gradient(135deg, #f97316 0%, #c2410c 100%);
+  color: white !important;
+}
+
+.intermediate-badge,
+.advanced-badge {
+  letter-spacing: 0.5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Progress percentage styling */


### PR DESCRIPTION
## Summary
- enrich the beginner sections data with detailed descriptions and include the first practical-life units to open Section 3
- generalize the SimpleUnitsList unlocking logic with reusable helpers, tailored motivational messaging, and level badges across sections
- extend styling to support the new Section 3 palette and advanced unit visuals for A2 practical content

## Testing
- CI=true npm test -- --watch=false
- npm run build *(fails: existing MUI Grid type errors regarding removed `item`/`xs` props)*

------
https://chatgpt.com/codex/tasks/task_e_68d527d5bf8083289c0448b1187849d8