### PR TITLE
docs: renforcer le pilotage pédagogique continu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ Bienvenue dans le dépôt de l'application **Lëtzebuergesch Léieren**. Ce docu
 
 ## 1. Gouvernance de produit (vision chef·fe de projet)
 - Avant toute évolution fonctionnelle, consultez `CHEF_PROJET_ROADMAP.md`, `Architecture-Analysis-48-Units.md` et `CONSTRUCTION_RESUME.md` pour vérifier l'alignement stratégique.
+- Pour les initiatives pédagogiques luxembourgeoises, complétez cette revue avec `Pedagogical_Strategy_Rework.md` (notamment son Étape 6 sur le pilotage continu) afin de garantir la cohérence du parcours et la boucle d'amélioration.
 - Documentez toute fonctionnalité livrée ou retirée dans `README-APP.md` et mettez à jour les diagrammes ou notes d'architecture concernées.
 - Maintenez la cohérence des parcours pédagogiques : si une unité change, revoyez les dépendances et l'impact sur les tests end-to-end.
 

--- a/Pedagogical_Strategy_Rework.md
+++ b/Pedagogical_Strategy_Rework.md
@@ -1,0 +1,112 @@
+# 📚 Stratégie pédagogique révisée pour « Lëtzebuergesch Léieren »
+
+## Étape 1 — Diagnostic linguistique et pédagogique
+- **Pertinence thématique** : les unités actuelles couvrent des situations utiles mais restent très ciblées, ce qui fragmente la progression et empêche l'apprenant·e de construire une vision globale du luxembourgeois quotidien.
+- **Scaffolding insuffisant** : l'enchaînement lexical/grammatical n'est pas toujours indiqué ; l'apprenant·e ne sait pas quelles compétences sont consolidées ou introduites.
+- **Compétences CECRL** : certaines unités mélangent niveaux A1/A2 sans gradation explicite ; la charge cognitive peut devenir excessive.
+- **Culture et motivation** : les éléments culturels apparaissent ponctuellement mais ne sont pas scénarisés pour encourager l'immersion et la confiance.
+
+## Étape 2 — Principes directeurs de la refonte
+1. **Progression spiralaire A1 → B2** : réactiver 30 % des acquis dans chaque unité et introduire au plus 7 items lexicaux nouveaux par leçon A1/A1+, 10 items A2, 12 items B1/B2.
+2. **Alignement CECRL** : associer chaque unité à un objectif fonctionnel (« Je peux… ») et à la compétence dominante (interaction orale, production, compréhension, médiation).
+3. **Trame linguistique complète** : articuler systématiquement lexique, grammaire, prononciation (phonèmes difficiles : ë/é/ä), pragmatique et interculturel.
+4. **Tâche finale contextualisée** : clôturer chaque unité par une mini-mission authentique (ex. prendre rendez-vous à la commune, participer à une réunion multilingue).
+5. **Encouragements et métalangage** : fournir feedback positif en luxembourgeois simple (« Super gemaach! ») avec traduction pour renforcer l'autonomie.
+
+## Étape 3 — Architecture progressive des sections
+Chaque section comprend 8 unités. Les tableaux ci-dessous précisent le niveau, les fonctions communicatives, les apports linguistiques et la tâche finale de synthèse.
+
+### Section 1 — "Premiers pas" (A1) : survie linguistique et confiance
+| Unité | Objectif "Je peux…" | Lexique clé | Grammaire/Prononciation | Tâche finale authentique |
+| --- | --- | --- | --- | --- |
+| 1. Premières rencontres | dire bonjour, me présenter | moien, salut, mäin Numm, ech sinn, vu wou | ordre S-V, intonation interrogative, voyelle « ë » | Enregistrer un message audio « Moien, ech sinn … » pour un groupe d'accueil |
+| 2. Identité et coordonnées | donner nom, origine, contact | ech wunnen, Hausnummer, Telefonsnummer, E-Mail | Verbes réguliers « sinn », « wunnen », chiffres 0-9 | Remplir un formulaire en ligne pour la bibliothèque de Lëtzebuerg |
+| 3. Nombres et quantités | compter, donner prix simples | een, zwou, dräi, véier, fënnef, wéi vill | Accord des nombres avec noms, accent tonique | Commander deux billets de bus auprès d'un guichet CFL |
+| 4. Temps et rendez-vous | parler de la date et l'heure | haut, muer, moies, owes, Mëttwoch | Questions avec « wéini », préposition « um », phonème « äu » | Fixer un rendez-vous médical par téléphone |
+| 5. Famille proche | décrire la famille immédiate | Mamm, Papp, Geschwëster, Kand, bestuet | Possessifs (mäin, deng, säin), pluriels irréguliers | Présenter sa famille à une institutrice lors d'une réunion |
+| 6. Se déplacer | demander/indiquer direction | lénks, riets, riichtaus, bei, virun | Impératif poli « kënnt Dir…? », fusion articles/prepositions | Guider un visiteur vers la Place Guillaume II |
+| 7. Urgences | solliciter aide, expliquer problème | Hëllef, Dokter, Pompjeeën, Accident, ech hunn | Modal « muss », structure « ech brauch », numéros 112/113 | Simuler un appel d'urgence en respectant protocole luxembourgeois |
+| 8. Politesse et rituels | interagir avec politesse formelle | w.e.g., Merci villmools, Entschëllegt, däerf ech | Différence « du/Dir », particules de courtoisie | Dialoguer avec un·e agent·e communal·e pour une demande d'information |
+
+### Section 2 — "Communication quotidienne" (A1+) : interactions sociales fluides
+| Unité | Objectif | Lexique clé | Grammaire/Prononciation | Tâche finale |
+| --- | --- | --- | --- | --- |
+| 9. Bien-être et sentiments simples | exprimer comment ça va | Et geet, midd, frou, krank, ech hu Loscht | Verbe « hunn », adjectifs attributs, particules « awer » | Partager son humeur dans un groupe WhatsApp du cours |
+| 10. Courses et marché | acheter produits de base | Brout, Gromperen, Präis, Reduktioun | Questions avec « wéi vill kascht », pluriel massif | Effectuer des achats au marché de la Place Guillaume II |
+| 11. Café et restaurant | commander, payer | Dësch, Menu, Ech hätt gär, Rechnong | Conditionnel de politesse, prononciation « ch » | Commander un menu luxembourgeois typique au restaurant |
+| 12. Transports publics | planifier trajet | Buskaart, Arrêt, fueren, ukommen, zréck | Verbe « fueren », prépositions directionnelles, horaires | Construire un itinéraire CFL + TICE pour aller au travail |
+| 13. Météo et vêtements | parler météo, adapter tenue | Wieder, sonneg, reenen, Schal, Reemantel | Futur proche « ech ginn », accord adjectif + temps | Conseiller un·e ami·e sur quoi porter en hiver luxembourgeois |
+| 14. Loisirs et invitations | proposer activités | spillen, kino, Concert, zesumme | Verbe modaux « wëllen », « kënnen », invitation | Organiser une sortie à la Schueberfouer |
+| 15. Rendez-vous et agenda | fixer rendez-vous social | disponibel, kalennert, um wéi vill Auer | Structures temporelles complexes, expression durée | Gérer un agenda partagé pour un club linguistique |
+| 16. Téléphone et messages | laisser message clair | Stëmmbox, Ech ruffen zréck, direkt, spéider | Discours rapporté simple, intonation téléphonique | Laisser un message vocal professionnel concis |
+
+### Section 3 — "Vie pratique" (A2) : autonomie dans les démarches
+| Unité | Objectif | Lexique clé | Grammaire/Prononciation | Tâche finale |
+| --- | --- | --- | --- | --- |
+| 17. Logement | chercher, décrire logement | Appartement, Locatioun, Loyers, Quartier | Comparatifs, prépositions locatives précises | Présenter une annonce immobilière à un·e ami·e |
+| 18. Santé | expliquer symptômes, consulter | Rendez-vous, Rezept, Medikament, Versécherung | Passé composé (« ech hunn gehat »), impératif soins | Préparer visite chez le médecin généraliste |
+| 19. Banque et finances | ouvrir compte, gérer budget | Kont, Spuerkeess, Virement, Fraisen | Vocabulaire financier, tournures formelles, chiffres grands | Simuler ouverture de compte à la Banque et Caisse d'Épargne |
+| 20. Travail quotidien | interagir au bureau | Kolleg, Reunioun, Deadline, Dossier | Présent progressif « ech sinn amgaang », modaux obligation | Participer à un briefing d'équipe multilingue |
+| 21. Voyager au Luxembourg | planifier excursions | Ticket kombinéiert, Muséeën, Wanderweeër | Futur périphrastique, conjonctions « well », « obwuel » | Organiser un week-end à Clervaux et Mullerthal |
+| 22. Mode et services | faire du shopping spécialisé | Gréisst, ëmtausche, Service no-verkaf, Garantie | Pronoms objets, verbes séparables (usprobéieren) | Gérer un échange de vêtement dans une boutique |
+| 23. Alimentation et cuisine | suivre recettes locales | Bouneschlupp, Grompereszalot, Zutaten | Impératif pluriel, quantificateurs, unités mesure | Préparer une recette luxembourgeoise filmée |
+| 24. Services publics | interagir avec administrations | Gemeng, Formulaire, Rendez-vous fixé, Dokumenter | Formules formelles, voix passive simple | Compléter un dossier d'inscription à la commune |
+
+### Section 4 — "Culture et société" (A2+) : immersion citoyenne
+| Unité | Objectif | Lexique clé | Grammaire/Prononciation | Tâche finale |
+| --- | --- | --- | --- | --- |
+| 25. Histoire du Luxembourg | résumer faits historiques | Groussherzogtum, Onofhängegkeet, Neutralitéit | Passé narratif, connecteurs temporels | Préparer une capsule audio historique pour nouveaux résidents |
+| 26. Traditions et fêtes | expliquer coutumes | Schueberfouer, Emaischen, Liichten | Aspect lexical régional, rythme prosodique | Proposer un calendrier de fêtes locales à des parents |
+| 27. Institutions politiques | comprendre structure | Chamber, Regierung, Gemengeconsell | Lexique politique, voix passive, modaux devoir | Simuler une discussion citoyenne sur un projet local |
+| 28. Éducation et formation | présenter système scolaire | Grondschoul, Lycée, Formation professionnelle | Discours indirect, subordonnées causales | Conseiller un couple sur les parcours scolaires |
+| 29. Médias et information | analyser sources | Zeitungen, Noriichten, Radiosender, Onlineportal | Comparaison registres, citations, prononciation « z » | Créer une revue de presse bilingue |
+| 30. Sports et santé publique | discuter activités collectives | LetzBoyz, Vélo'Box, Sportshal | Expression de fréquence, connecteurs argumentatifs | Concevoir une affiche de promotion santé municipale |
+| 31. Vie culturelle | recommander événements | Philharmonie, Mudam, Festival de Wiltz | Registre persuasif, adjectifs nuancés | Planifier un itinéraire culturel week-end |
+| 32. Géographie et mobilité | décrire territoires | Norden, Süden, Éislek, Musel | Prépositions mixtes, structures conditionnelles simples | Préparer présentation touristique interactive |
+
+### Section 5 — "Expression personnelle" (B1) : nuances et opinions
+| Unité | Objectif | Lexique clé | Grammaire/Prononciation | Tâche finale |
+| --- | --- | --- | --- | --- |
+| 33. Émotions complexes | exprimer sentiments nuancés | houfreg, enttäuscht, iwwerrascht | Temps composé + adverbes intensité, particule « zwar » | Écrire un journal personnel audio |
+| 34. Relations et communication | gérer conflits, empathie | Vertraulechkeet, Konflikt léisen, empathesch | Discours rapporté avancé, structures hypothétiques | Jouer scène de médiation entre collègues |
+| 35. Projets et planification | présenter projets personnels | Pläng, Ziler, Zäitplang, Ressourcen | Futur complexe, connecteurs logiques | Pitcher un projet associatif local |
+| 36. Expériences et récits | raconter événements passés | erlieft, verpasst, erënneren | Passé narratif varié, aspect perfectif/imperfectif | Produire un podcast narratif |
+| 37. Opinion et débat | argumenter, nuancer | ech mengen, ech sinn averstanen, awer, dobäi | Argumentation structurée, connecteurs concessifs | Débat sur une question citoyenne |
+| 38. Créativité et culture | parler préférences artistiques | Konscht, Literatur, Musek, Inspiratioun | Vocabulaire esthétique, modaux subjectifs | Écrire critique courte d'une expo au Mudam |
+| 39. Engagement social | évoquer implication | fräiwëlleg, ONG, Solidaires | Mode subjonctif émergent, registre formel | Concevoir campagne bénévolat |
+| 40. Vie numérique | gérer interactions en ligne | Privatsphär, Sécherheet, sozialen Netzwierker | Conditionnel, injonctions polies, anglicismes adaptés | Animer discussion en ligne modérée |
+
+### Section 6 — "Maîtrise professionnelle" (B1+/B2) : interactions expertes
+| Unité | Objectif | Lexique clé | Grammaire/Prononciation | Tâche finale |
+| --- | --- | --- | --- | --- |
+| 41. Présentations professionnelles | exposer idées complexes | Presentatioun, Strategie, Stakeholder | Discours structuré, connecteurs avancés | Présenter un projet à un comité bilingue |
+| 42. Réunions multilingues | négocier, clarifier | Agenda, Protokoll, Entscheedung | Médiation interlinguistique, reformulation | Animer réunion mixte LB/FR/DE |
+| 43. Correspondance officielle | rédiger emails formels | Ufro, Beschwéier, Attaché, Notiz | Registre administratif, structures passives complexes | Rédiger réponse officielle à l'administration |
+| 44. Analyse et rapports | synthétiser données | Analys, Grafiken, Erkenntnis | Lexique spécialisé, participes substantivés | Présenter un rapport synthétique |
+| 45. Gestion de projets | coordonner équipes | Ressourceplang, Échéancier, Risikomanagement | Structures causales avancées, voix passive | Construire plan de projet complet |
+| 46. Culture d'entreprise | expliquer valeurs | Entreprisekultur, Diversitéit, Inclusion | Expressions idiomatiques, modaux nuancés | Concevoir atelier inclusion au travail |
+| 47. Leadership et feedback | donner feedback constructif | Feedback, Leeschtung, Verbesserungsvirschlag | Conditionnel passé, tournures diplomatiques | Simuler entretien annuel |
+| 48. Vision européenne | participer discussions UE | Reglement, Directive, Kommissioun, Impakt | Lexique institutionnel, argumentation comparative | Débattre d'une proposition européenne en luxembourgeois |
+
+## Étape 4 — Modalités d'apprentissage et outils
+- **Rituels de révision** : flashcards ciblées (lexique + phrases modèles), micro-dialogues audio et dictées actives.
+- **Prononciation guidée** : introduire mini-vidéos sur phonèmes difficiles (ä, ë, eu) et exercices de répétition avec feedback.
+- **Évaluation formative** : au moins une auto-évaluation "Ech kann elo…" par unité, avec score de confiance et conseils.
+- **Projets inter-unités** : chaque fin de section propose une mission cumulative (ex. organiser une journée d'intégration pour Section 2, réaliser un dossier administratif complet pour Section 3).
+
+## Étape 5 — Implémentation opérationnelle
+1. **Refactoriser `LearningPathData.ts`** pour refléter les nouvelles descriptions (titres, objectifs, couleurs thématiques).
+2. **Créer gabarits d'unité** intégrant champs : objectif CECRL, tâches, révision précédente, notes culturelles.
+3. **Prioriser Section 1 complète** avec cette nouvelle structure avant d'étendre.
+4. **Mettre en place indicateurs** : % de réussite par compétence, progression CECRL, suivi motivation (messages "Du bass um richtege Wee!").
+5. **Boucles de validation** : relecture linguistique (orthographe luxembourgeoise), test utilisateur, ajustement.
+
+## Étape 6 — Pilotage pédagogique et accompagnement continu
+- **Comité linguistique trimestriel** : croiser les retours des apprenant·e·s, des enseignant·e·s et du/de la linguiste référent·e pour ajuster les contenus et garantir la cohérence interculturelle.
+- **Tableau de bord qualitatif** : consigner exemples d'excellentes productions apprenantes, difficultés récurrentes (lexique, grammaire, prononciation) et actions correctives prévues.
+- **Mentorat entre pairs** : instaurer des binômes A2/B1 et B1/B2 qui s'enregistrent et s'évaluent mutuellement via une grille d'écoute, renforçant la motivation et l'autonomie.
+- **Documentation vivante** : archiver les itérations de scénarios de tâches finales et leurs scripts audio afin de faciliter la montée en charge de nouvelles personnes contributrices.
+
+---
+
+Cette stratégie assure une montée en compétence cohérente, motivante et alignée avec les attentes CECRL tout en respectant la spécificité culturelle luxembourgeoise.


### PR DESCRIPTION
## Summary
- enrichir la stratégie pédagogique avec une nouvelle étape dédiée au pilotage et à l’accompagnement continu des unités
- référencer cette gouvernance linguistique dans le guide AGENTS.md pour toutes les initiatives pédagogiques

## Testing
- `CI=true npm test -- --watch=false`
- `npm run build` *(fails: TS2769 lié aux anciens props MUI Grid `item`, `xs`, `md` déjà présents dans la base)*

------
https://chatgpt.com/codex/tasks/task_e_68d5333c0c9c83288d75066474e4b1ad