### PR TITLE
Enhance back navigation encouragement in units list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -424,8 +424,9 @@ function App() {
                 startIcon={<ArrowBackRoundedIcon />}
                 onClick={() => setCurrentView('menu')}
                 sx={{ borderRadius: 999 }}
+                aria-label="Zréck op d'Haaptmenü – du bass um richtege Wee! (Retour vers le menu principal)"
               >
-
+                Zréck op d'Haaptmenü – du bass um richtege Wee! (Retour vers le menu principal)
               </Button>
             )}
           </Stack>

--- a/src/__tests__/SimpleUnitsList.test.tsx
+++ b/src/__tests__/SimpleUnitsList.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SimpleUnitsList from '../components/SimpleUnitsList'
+
+describe('SimpleUnitsList', () => {
+  it('affiche le bouton de retour encourageant et déclenche onBack', async () => {
+    const user = userEvent.setup()
+    const onBack = jest.fn()
+
+    render(<SimpleUnitsList onBack={onBack} onUnitComplete={jest.fn()} />)
+
+    const backButton = screen.getByRole('button', {
+      name: /Zréck op d'Haaptmenü – du meeschters dat! \(Retour vers le menu principal\)/i
+    })
+
+    expect(backButton).toBeInTheDocument()
+
+    await user.click(backButton)
+
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/SimpleUnitsList.tsx
+++ b/src/components/SimpleUnitsList.tsx
@@ -185,6 +185,16 @@ const SimpleUnitsList: React.FC<SimpleUnitsListProps> = ({ onBack, onUnitComplet
           <h1>Sections d'apprentissage</h1>
           <p className="subtitle">Choisissez une unité pour commencer votre apprentissage</p>
         </div>
+        <div className="header-actions">
+          <button
+            type="button"
+            className="back-to-menu-button"
+            onClick={onBack}
+            aria-label="Zréck op d'Haaptmenü – du meeschters dat! (Retour vers le menu principal)"
+          >
+            ← Zréck op d'Haaptmenü – du meeschters dat! (Retour vers le menu principal)
+          </button>
+        </div>
       </div>
 
       <div className="sections-list">

--- a/src/styles/SimpleUnitsList.css
+++ b/src/styles/SimpleUnitsList.css
@@ -38,6 +38,40 @@
   margin-right: auto;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+}
+
+.back-to-menu-button {
+  background: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.back-to-menu-button:hover {
+  background: rgba(255, 255, 255, 0.3);
+  border-color: rgba(255, 255, 255, 0.8);
+  transform: translateY(-1px);
+}
+
+.back-to-menu-button:focus {
+  outline: 3px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 2px;
+}
+
+.back-to-menu-button:active {
+  transform: translateY(0);
+}
+
 .header-content h1 {
   color: white;
   font-size: 2.5rem;


### PR DESCRIPTION
## Summary
- add an encouraging Luxembourgish and French label plus aria metadata to the global back button for clearer accessibility
- render the SimpleUnitsList onBack action as a styled, positive call-to-action that guides learners to the main menu
- add a React Testing Library test that validates the button visibility and callback invocation for the units list header

## Testing
- npm test -- SimpleUnitsList.test.tsx --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68db808950148328bae41d17e04ead4c