### PR TITLE
Clarify beginner sections metadata and guard with test

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,13 +179,26 @@ function App() {
       {
         key: 'sections' as const,
         title: 'Sections d\'apprentissage',
-        description: 'Progressez de débutant à intermédiaire avec 2 sections complètes.',
+        description:
+          'Découverte guidée des 3 sections : des premiers échanges jusqu\'à l\'autonomie au quotidien.',
         icon: <SchoolRoundedIcon fontSize="medium" />,
         accent: 'primary',
         metadata: [
-          { icon: <MenuBookRoundedIcon fontSize="small" />, text: '2 sections progressives' },
-          { icon: <QueryStatsRoundedIcon fontSize="small" />, text: 'A1 → A1+ → A2' },
-          { icon: <EmojiEventsRoundedIcon fontSize="small" />, text: 'Unités 1-16 débloquées' }
+          {
+            icon: <MenuBookRoundedIcon fontSize="small" />,
+            text:
+              'Sektioun 1 – Éischt Schrëtt am Alldag (Unitë 1-8) · Section 1 – Premiers pas au quotidien (unités 1-8)'
+          },
+          {
+            icon: <QueryStatsRoundedIcon fontSize="small" />,
+            text:
+              'Sektioun 2 – Kommunikatioun am Alldag (Unitë 9-16) · Section 2 – Communication quotidienne (unités 9-16)'
+          },
+          {
+            icon: <EmojiEventsRoundedIcon fontSize="small" />,
+            text:
+              'Sektioun 3 – Praktescht Liewen & Autonomie (Unitë 17-24) · Section 3 – Vie pratique et autonomie (unités 17-24)'
+          }
         ],
         actionLabel: 'Explorer les sections',
         actionIcon: <ArrowForwardRoundedIcon />,

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import App from '../App'
+
+describe('App main menu learning cards', () => {
+  beforeEach(() => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      json: async () => ({
+        version: 'test',
+        buildHash: 'hash',
+        buildTime: 'now',
+        commitHash: 'commit'
+      })
+    } as Response)
+
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('presents the three sections with bilingual metadata chips', async () => {
+    render(<App />)
+
+    expect(
+      await screen.findByText(
+        'Sektioun 1 – Éischt Schrëtt am Alldag (Unitë 1-8) · Section 1 – Premiers pas au quotidien (unités 1-8)'
+      )
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByText(
+        'Sektioun 2 – Kommunikatioun am Alldag (Unitë 9-16) · Section 2 – Communication quotidienne (unités 9-16)'
+      )
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByText(
+        'Sektioun 3 – Praktescht Liewen & Autonomie (Unitë 17-24) · Section 3 – Vie pratique et autonomie (unités 17-24)'
+      )
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- update the main menu learning card so it names all three beginner sections with bilingual chips
- ensure the description highlights the full path from first exchanges to everyday autonomy
- add a regression test that renders the app menu and checks the Luxembourgish/French metadata chips

## Testing
- CI=true npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db80a52ccc8328b796f978b13a0474