### PR TITLE
Add dedicated vocabulary quiz dataset with pronunciation context

### DIFF
--- a/src/__tests__/VocabularyQuiz.test.tsx
+++ b/src/__tests__/VocabularyQuiz.test.tsx
@@ -1,20 +1,14 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import VocabularyQuiz from '../components/VocabularyQuiz'
+import { vocabularyQuizItems } from '../data/VocabularyQuizData'
 
-const vocabularySequence = [
-  { luxembourgish: 'Moien', french: 'Bonjour' },
-  { luxembourgish: 'Äddi', french: 'Au revoir' },
-  { luxembourgish: 'Merci', french: 'Merci' },
-  { luxembourgish: 'Pardon', french: 'Excusez-moi' },
-  { luxembourgish: 'Wéi geet et?', french: 'Comment allez-vous?' },
-  { luxembourgish: 'Ech verstinn net', french: 'Je ne comprends pas' },
-  { luxembourgish: 'Wou ass...?', french: 'Où est...?' },
-  { luxembourgish: 'Wéivill kascht dat?', french: 'Combien ça coûte?' },
-  { luxembourgish: 'Waasser', french: 'Eau' },
-  { luxembourgish: 'Kaffi', french: 'Café' }
-]
+const translationMap = new Map(
+  vocabularyQuizItems.map(item => [item.luxembourgish, item.french])
+)
 
-const translationMap = new Map(vocabularySequence.map(item => [item.luxembourgish, item.french]))
+const vocabularyDetailsMap = new Map(
+  vocabularyQuizItems.map(item => [item.luxembourgish, item])
+)
 
 describe('VocabularyQuiz', () => {
   let mathRandomSpy: jest.SpyInstance<number, []>
@@ -38,6 +32,13 @@ describe('VocabularyQuiz', () => {
     expect(match).not.toBeNull()
     const currentWord = match ? match[1].trim() : ''
     expect(translationMap.has(currentWord)).toBe(true)
+
+    const currentWordDetails = vocabularyDetailsMap.get(currentWord)
+    expect(currentWordDetails).toBeDefined()
+    expect(
+      screen.getByText(`Prononciation : ${currentWordDetails?.pronunciation}`)
+    ).toBeInTheDocument()
+    expect(screen.getByText(currentWordDetails!.usage)).toBeInTheDocument()
 
     const optionButtons = screen
       .getAllByRole('button')
@@ -97,7 +98,7 @@ describe('VocabularyQuiz', () => {
   it('shows the quiz result summary after answering all questions', async () => {
     render(<VocabularyQuiz />)
 
-    for (let index = 0; index < vocabularySequence.length; index += 1) {
+    for (let index = 0; index < vocabularyQuizItems.length; index += 1) {
       await screen.findByText(`Question ${index + 1}`)
 
       const heading = screen.getByRole('heading', { level: 3 })
@@ -110,7 +111,7 @@ describe('VocabularyQuiz', () => {
 
       fireEvent.click(screen.getByRole('button', { name: correctAnswer! }))
 
-      const nextLabel = index === vocabularySequence.length - 1 ? 'Terminer' : 'Question suivante'
+      const nextLabel = index === vocabularyQuizItems.length - 1 ? 'Terminer' : 'Question suivante'
       fireEvent.click(screen.getByRole('button', { name: nextLabel }))
     }
 

--- a/src/components/VocabularyQuiz.tsx
+++ b/src/components/VocabularyQuiz.tsx
@@ -12,41 +12,24 @@ import {
 import QuizRoundedIcon from '@mui/icons-material/QuizRounded'
 import AutoAwesomeRoundedIcon from '@mui/icons-material/AutoAwesomeRounded'
 
-interface VocabularyItem {
-  luxembourgish: string
-  french: string
-  category: string
-}
-
-const vocabularyData: VocabularyItem[] = [
-  { luxembourgish: 'Moien', french: 'Bonjour', category: 'salutations' },
-  { luxembourgish: 'Äddi', french: 'Au revoir', category: 'salutations' },
-  { luxembourgish: 'Merci', french: 'Merci', category: 'politesse' },
-  { luxembourgish: 'Pardon', french: 'Excusez-moi', category: 'politesse' },
-  { luxembourgish: 'Wéi geet et?', french: 'Comment allez-vous?', category: 'conversation' },
-  { luxembourgish: 'Ech verstinn net', french: 'Je ne comprends pas', category: 'conversation' },
-  { luxembourgish: 'Wou ass...?', french: 'Où est...?', category: 'questions' },
-  { luxembourgish: 'Wéivill kascht dat?', french: 'Combien ça coûte?', category: 'questions' },
-  { luxembourgish: 'Waasser', french: 'Eau', category: 'nourriture' },
-  { luxembourgish: 'Kaffi', french: 'Café', category: 'nourriture' }
-]
+import { vocabularyQuizItems, VocabularyQuizItem } from '../data/VocabularyQuizData'
 
 const VocabularyQuiz = () => {
   const [currentQuestion, setCurrentQuestion] = useState(0)
   const [score, setScore] = useState(0)
   const [selectedAnswer, setSelectedAnswer] = useState('')
   const [showResult, setShowResult] = useState(false)
-  const [shuffledQuestions, setShuffledQuestions] = useState<VocabularyItem[]>([])
+  const [shuffledQuestions, setShuffledQuestions] = useState<VocabularyQuizItem[]>([])
   const [options, setOptions] = useState<string[]>([])
 
   useEffect(() => {
-    const shuffled = [...vocabularyData].sort(() => Math.random() - 0.5)
+    const shuffled = [...vocabularyQuizItems].sort(() => Math.random() - 0.5)
     setShuffledQuestions(shuffled)
     generateOptions(shuffled[0])
   }, [])
 
-  const generateOptions = (correct: VocabularyItem) => {
-    const incorrectOptions = vocabularyData
+  const generateOptions = (correct: VocabularyQuizItem) => {
+    const incorrectOptions = vocabularyQuizItems
       .filter(item => item.french !== correct.french)
       .sort(() => Math.random() - 0.5)
       .slice(0, 3)
@@ -80,7 +63,7 @@ const VocabularyQuiz = () => {
     setScore(0)
     setSelectedAnswer('')
     setShowResult(false)
-    const shuffled = [...vocabularyData].sort(() => Math.random() - 0.5)
+    const shuffled = [...vocabularyQuizItems].sort(() => Math.random() - 0.5)
     setShuffledQuestions(shuffled)
     generateOptions(shuffled[0])
   }
@@ -186,6 +169,12 @@ const VocabularyQuiz = () => {
           <Typography variant="h3" sx={{ mt: 1 }}>
             « {currentWord.luxembourgish} »
           </Typography>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ mt: 1 }}>
+            Prononciation : {currentWord.pronunciation}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+            {currentWord.usage}
+          </Typography>
         </Box>
 
         <Stack spacing={1.5}>
@@ -195,7 +184,7 @@ const VocabularyQuiz = () => {
 
             return (
               <Button
-                key={option}
+                key={`${currentWord.id}-${option}`}
                 onClick={() => handleAnswerSelect(option)}
                 variant={isSelected ? 'contained' : 'outlined'}
                 color={isSelected ? 'primary' : 'inherit'}

--- a/src/data/VocabularyQuizData.ts
+++ b/src/data/VocabularyQuizData.ts
@@ -1,0 +1,88 @@
+import { VocabularyItem } from '../types/LearningTypes'
+
+export interface VocabularyQuizItem extends VocabularyItem {
+  category: 'salutations' | 'politesse' | 'conversation' | 'questions' | 'nourriture'
+}
+
+export const vocabularyQuizItems: VocabularyQuizItem[] = [
+  {
+    id: 'moien',
+    luxembourgish: 'Moien',
+    french: 'Bonjour',
+    pronunciation: 'MOY-en',
+    usage: "Formule chaleureuse pour dire bonjour et ouvrir un échange avec un sourire.",
+    category: 'salutations'
+  },
+  {
+    id: 'addi',
+    luxembourgish: 'Äddi',
+    french: 'Au revoir',
+    pronunciation: 'AED-di',
+    usage: "Permet de prendre congé avec politesse tout en laissant une impression positive.",
+    category: 'salutations'
+  },
+  {
+    id: 'merci',
+    luxembourgish: 'Merci',
+    french: 'Merci',
+    pronunciation: 'MER-see',
+    usage: "Exprime une gratitude sincère qui encourage la bienveillance réciproque.",
+    category: 'politesse'
+  },
+  {
+    id: 'pardon',
+    luxembourgish: 'Pardon',
+    french: 'Excusez-moi',
+    pronunciation: 'PAR-don',
+    usage: "Idéal pour attirer l’attention avec douceur ou présenter des excuses respectueuses.",
+    category: 'politesse'
+  },
+  {
+    id: 'wei_geet_et',
+    luxembourgish: 'Wéi geet et?',
+    french: 'Comment allez-vous?',
+    pronunciation: 'VAY gate et',
+    usage: "Invite l’interlocuteur à partager son ressenti et renforce la connexion humaine.",
+    category: 'conversation'
+  },
+  {
+    id: 'ech_verstinn_net',
+    luxembourgish: 'Ech verstinn net',
+    french: 'Je ne comprends pas',
+    pronunciation: 'EHKH fer-STIN net',
+    usage: "Exprime clairement un besoin d’aide tout en restant respectueux et motivé.",
+    category: 'conversation'
+  },
+  {
+    id: 'wou_ass',
+    luxembourgish: 'Wou ass...?',
+    french: 'Où est...?',
+    pronunciation: 'VOU ass',
+    usage: "Question utile pour se repérer et favoriser les échanges pratiques au quotidien.",
+    category: 'questions'
+  },
+  {
+    id: 'weivill_kascht_dat',
+    luxembourgish: 'Wéivill kascht dat?',
+    french: 'Combien ça coûte?',
+    pronunciation: 'VAY-vill KASHT dat',
+    usage: "Permet de gérer ses achats avec assurance et de pratiquer le luxembourgeois en situation réelle.",
+    category: 'questions'
+  },
+  {
+    id: 'waasser',
+    luxembourgish: 'Waasser',
+    french: 'Eau',
+    pronunciation: 'VAH-ser',
+    usage: "Mot indispensable pour commander à boire et prendre soin de soi en toute circonstance.",
+    category: 'nourriture'
+  },
+  {
+    id: 'kaffi',
+    luxembourgish: 'Kaffi',
+    french: 'Café',
+    pronunciation: 'KAF-fi',
+    usage: "Idéal pour partager une pause conviviale et tisser des liens autour d’une boisson chaude.",
+    category: 'nourriture'
+  }
+]


### PR DESCRIPTION
## Summary
- extract the vocabulary quiz entries into a typed data module with pronunciation and usage context
- update the quiz component to consume the shared data and surface the extra learner guidance in the UI
- align the VocabularyQuiz tests with the new module and assert the pronunciation and usage rendering

## Testing
- CI=true npm test -- VocabularyQuiz
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db80c3e82883288534b6e4ae059794